### PR TITLE
Use module path for selecting current module

### DIFF
--- a/src/app/components/sandbox/CodeEditor/Header.js
+++ b/src/app/components/sandbox/CodeEditor/Header.js
@@ -32,28 +32,34 @@ const Buttons = styled.div`
 `;
 
 type Props = {
-  title: string,
   path: string,
   saveComponent: ?() => void,
   prettify: ?Function,
 };
 
-export default ({ path, title, saveComponent, prettify }: Props) => (
-  <Container>
-    <div>
-      <Path>{path}</Path>
-      {title}
-    </div>
+export default ({ path, saveComponent, prettify }: Props) => {
+  const pathParts = path.split('/');
+  const fileName = pathParts[pathParts.length - 1];
+  const pathName = pathParts.slice(0, pathParts.length - 1).join('/');
+  return (
+    <Container>
+      <div>
+        <Path>
+          {pathName}/
+        </Path>
+        {fileName}
+      </div>
 
-    <Buttons>
-      <Tooltip position="bottom" title="Made possible by Prettier">
-        <Button disabled={!prettify} onClick={prettify} small>
-          Prettify
+      <Buttons>
+        <Tooltip position="bottom" title="Made possible by Prettier">
+          <Button disabled={!prettify} onClick={prettify} small>
+            Prettify
+          </Button>
+        </Tooltip>
+        <Button disabled={!saveComponent} onClick={saveComponent} small>
+          Save
         </Button>
-      </Tooltip>
-      <Button disabled={!saveComponent} onClick={saveComponent} small>
-        Save
-      </Button>
-    </Buttons>
-  </Container>
-);
+      </Buttons>
+    </Container>
+  );
+};

--- a/src/app/components/sandbox/CodeEditor/index.js
+++ b/src/app/components/sandbox/CodeEditor/index.js
@@ -460,20 +460,13 @@ export default class CodeEditor extends React.PureComponent {
   server: typeof CodeMirror.TernServer;
 
   render() {
-    const {
-      title,
-      canSave,
-      onlyViewMode,
-      modulePath,
-      preferences,
-    } = this.props;
+    const { canSave, onlyViewMode, modulePath, preferences } = this.props;
 
     return (
       <Container>
         <Header
           saveComponent={canSave && !onlyViewMode && this.handleSaveCode}
           prettify={!onlyViewMode && this.prettify}
-          title={title}
           path={modulePath}
         />
         <CodeContainer

--- a/src/app/pages/Sandbox/Editor/Content/Header/ShareView.js
+++ b/src/app/pages/Sandbox/Editor/Content/Header/ShareView.js
@@ -8,6 +8,7 @@ import ModeIcons from 'app/components/sandbox/ModeIcons';
 import {
   findMainModule,
   modulesFromSandboxSelector,
+  getModulePath,
 } from 'app/store/entities/sandboxes/modules/selectors';
 import { directoriesFromSandboxSelector } from 'app/store/entities/sandboxes/directories/selectors';
 import {
@@ -172,9 +173,11 @@ class ShareView extends React.PureComponent {
   setMixedView = () => this.setState({ showEditor: true, showPreview: true });
 
   setDefaultModule = id => this.setState({ defaultModule: id });
+
   clearDefaultModule = () => this.setState({ defaultModule: null });
 
   getOptionsUrl = () => {
+    const { modules, directories } = this.props;
     const {
       defaultModule,
       showEditor,
@@ -188,9 +191,10 @@ class ShareView extends React.PureComponent {
 
     const options = {};
 
-    const mainModuleShortid = findMainModule(this.props.modules).shortid;
-    if (defaultModule && defaultModule !== mainModuleShortid) {
-      options.module = defaultModule;
+    const mainModuleId = findMainModule(modules).id;
+    if (defaultModule && defaultModule !== mainModuleId) {
+      const modulePath = getModulePath(modules, directories, defaultModule);
+      options.module = modulePath;
     }
 
     if (showEditor && !showPreview) {
@@ -291,7 +295,7 @@ class ShareView extends React.PureComponent {
     } = this.state;
 
     const defaultModule =
-      this.state.defaultModule || findMainModule(modules).shortid;
+      this.state.defaultModule || findMainModule(modules).id;
 
     return (
       <Container>

--- a/src/app/pages/Sandbox/Editor/Content/index.js
+++ b/src/app/pages/Sandbox/Editor/Content/index.js
@@ -139,6 +139,7 @@ class EditorPreview extends React.PureComponent {
 
     const currentModule = findCurrentModule(
       modules,
+      directories,
       currentModuleId,
       mainModule,
     );

--- a/src/app/pages/Sandbox/Editor/Workspace/Files/index.js
+++ b/src/app/pages/Sandbox/Editor/Workspace/Files/index.js
@@ -54,6 +54,7 @@ class Files extends React.PureComponent {
     const { currentModule: currentModuleId } = sandbox;
     const currentModule = findCurrentModule(
       modules,
+      directories,
       currentModuleId,
       mainModule,
     );

--- a/src/embed/components/Content.js
+++ b/src/embed/components/Content.js
@@ -8,6 +8,10 @@ import { getModulePath } from 'app/store/entities/sandboxes/modules/selectors';
 
 import type { Sandbox, Module, ModuleError } from 'common/types';
 import fetchBundle from 'app/store/entities/sandboxes/bundler';
+import {
+  findCurrentModule,
+  findMainModule,
+} from '../../app/store/entities/sandboxes/modules/selectors';
 
 const Container = styled.div`
   display: flex;
@@ -178,6 +182,7 @@ export default class Content extends React.PureComponent {
       sandbox,
       showEditor,
       showPreview,
+
       isInProjectView,
       currentModule,
       hideNavigation,
@@ -188,11 +193,12 @@ export default class Content extends React.PureComponent {
     const alteredModules = this.getAlteredModules();
 
     // $FlowIssue
-    const mainModule: Module =
-      alteredModules.find((m: Module) => m.shortid === currentModule) ||
-      alteredModules.find(
-        (m: Module) => m.title === 'index.js' && m.directoryShortid == null,
-      );
+    const mainModule: Module = findCurrentModule(
+      sandbox.modules,
+      sandbox.directories,
+      currentModule,
+      findMainModule(sandbox.modules),
+    );
 
     if (!mainModule) throw new Error('Cannot find main module');
 

--- a/src/embed/components/File.js
+++ b/src/embed/components/File.js
@@ -8,16 +8,15 @@ import Entry from 'app/pages/Sandbox/Editor/Workspace/EntryContainer';
 
 type Props = {
   id: string,
+  shortid: string,
   title: string,
   type: 'module' | 'directory',
-  setCurrentModule: (id: string) => void,
+  setCurrentModule: (shortid: string, id: string) => void,
   depth: number,
   active?: boolean,
   alternative?: boolean,
 };
-const LeftOffset = styled.div`
-  padding-left: ${props => props.depth}rem;
-`;
+const LeftOffset = styled.div`padding-left: ${props => props.depth}rem;`;
 
 export default class File extends React.PureComponent {
   props: Props;
@@ -40,9 +39,9 @@ export default class File extends React.PureComponent {
   };
 
   setCurrentModule = () => {
-    const { id, setCurrentModule } = this.props;
+    const { id, shortid, setCurrentModule } = this.props;
 
-    setCurrentModule(id);
+    setCurrentModule(id, shortid);
   };
 
   render() {
@@ -54,7 +53,9 @@ export default class File extends React.PureComponent {
           active={active}
           onClick={this.setCurrentModule}
         >
-          <LeftOffset depth={depth}>{this.getIcon()} {title}</LeftOffset>
+          <LeftOffset depth={depth}>
+            {this.getIcon()} {title}
+          </LeftOffset>
         </Entry>
       </div>
     );

--- a/src/embed/components/Files.js
+++ b/src/embed/components/Files.js
@@ -15,7 +15,7 @@ type Props = {
   directoryId: string,
   depth: number,
   currentModule: string,
-  setCurrentModule: (id: string) => any,
+  setCurrentModule: (id: string, shortid: string) => any,
 };
 
 const Files = ({
@@ -39,7 +39,8 @@ const Files = ({
       {sortBy(childrenDirectories, d => d.title).map(d =>
         <div key={d.shortid}>
           <File
-            id={d.shortid}
+            id={d.id}
+            shortid={d.shortid}
             title={d.title}
             type="directory"
             depth={depth}
@@ -57,13 +58,14 @@ const Files = ({
       )}
       {sortBy(childrenModules, m => m.title).map(m =>
         <File
-          id={m.shortid}
+          id={m.id}
+          shortid={m.shortid}
           title={m.title}
           key={m.shortid}
           type="module"
           depth={depth}
           setCurrentModule={setCurrentModule}
-          active={m.shortid === currentModule}
+          active={m.id === currentModule}
           alternative={m.title === 'index.js' && m.directoryShortid == null}
         />,
       )}

--- a/src/sandbox/utils/resolve-module.js
+++ b/src/sandbox/utils/resolve-module.js
@@ -16,11 +16,12 @@ const throwError = (path: string) => {
  * Convert the module path to a module
  */
 export default (
-  path: string,
+  path: ?string,
   modules: Array<Module>,
   directories: Array<Directory>,
   startdirectoryShortid: ?string = undefined,
 ) => {
+  if (!path) return null;
   // Split path
   const splitPath = path.replace(/^.\//, '').split('/');
   const foundDirectoryShortid = splitPath.reduce(


### PR DESCRIPTION
Need to review this PR myself too later today.

This changes the url structure from:

`/s/new?module=J38najh`
to
`/s/new?module=%20FHello.js`

Which means that now default modules are specified using paths instead of shortids, since shortids can change between updates. There should still be backward compatability with shortid.