### PR TITLE
fix vim mode switch

### DIFF
--- a/src/app/utils/codemirror/eslint-lint.js
+++ b/src/app/utils/codemirror/eslint-lint.js
@@ -375,8 +375,9 @@ export default (async function initialize() {
   while (!window.eslint) {
     // eslint-disable-next-line
     await delay(100);
-    window.require = origRequire;
   }
+
+  window.require = origRequire;
 
   linter = new window.eslint();
   linter.defineRules(allRules);

--- a/src/app/utils/codemirror/eslint-lint.js
+++ b/src/app/utils/codemirror/eslint-lint.js
@@ -354,7 +354,15 @@ export function fix(source: string) {
 }
 
 export default (async function initialize() {
-  if (!window.eslint && linter === null) {
+  // ugly hack to work around eslint dependency which redefines the require instance on window
+  // this breaks the monaco loader.js
+  // the following workaround can be removed after migration to monaco (vim mode) is done
+  const origRequire = window.require;
+  if (
+    !window.eslint &&
+    linter === null &&
+    !document.querySelector("script[src='/static/js/eslint.4.1.0.min.js']")
+  ) {
     // Add eslint as script
     const script = document.createElement('script');
     const src = '/static/js/eslint.4.1.0.min.js';
@@ -367,6 +375,7 @@ export default (async function initialize() {
   while (!window.eslint) {
     // eslint-disable-next-line
     await delay(100);
+    window.require = origRequire;
   }
 
   linter = new window.eslint();


### PR DESCRIPTION
ugly hack to work around eslint dependency which redefines the require instance on window
this breaks the monaco loader.js
the following workaround can be removed after migration to monaco (vim mode) is done

That is the most basic solution I could came up with. Please let me know what you think :)

fixes #118 