### PR TITLE
Make action tooltips positions more consistent

### DIFF
--- a/src/app/pages/Sandbox/Editor/Content/Header/Action.js
+++ b/src/app/pages/Sandbox/Editor/Content/Header/Action.js
@@ -147,7 +147,7 @@ export default ({
   if (href && a && (placeholder || tooltip)) {
     return (
       <ActionA href={href} target="_blank" rel="noopener noreferrer">
-        <Tooltip title={placeholder || tooltip}>
+        <ActionTooltip title={placeholder || tooltip}>
           <IconContainer {...iconContainerProps}>
             <Icon {...iconProps} />
             {title !== undefined &&
@@ -156,7 +156,7 @@ export default ({
               </Title>}
             {moreInfo && <MoreInfoIcon style={{ fontSize: '1.1rem' }} />}
           </IconContainer>
-        </Tooltip>
+        </ActionTooltip>
       </ActionA>
     );
   }
@@ -164,7 +164,7 @@ export default ({
   if (href && (placeholder || tooltip)) {
     return (
       <ActionLink to={href} {...props}>
-        <Tooltip title={placeholder || tooltip}>
+        <ActionTooltip title={placeholder || tooltip}>
           <IconContainer>
             <Icon {...iconProps} />
             {title !== undefined &&
@@ -173,7 +173,7 @@ export default ({
               </Title>}
             {moreInfo && <MoreInfoIcon style={{ fontSize: '1.1rem' }} />}
           </IconContainer>
-        </Tooltip>
+        </ActionTooltip>
       </ActionLink>
     );
   }


### PR DESCRIPTION
Current behaviour:
![current](https://user-images.githubusercontent.com/9586897/29495961-a36fe288-85d1-11e7-876a-8f8a37fb7178.gif)

With this PR:
![after](https://user-images.githubusercontent.com/9586897/29495964-abc84a9c-85d1-11e7-9f62-451a2c51e9f1.gif)

Now all the tooltips are aligned in the same position and the blue bottom border is visible on hover on the actions. I believe this is the original idea behind the hover behaviour for these actions. If I assumed wrong, please let me know how you'd like it to be! 😄

Created an issue as well: https://github.com/CompuIves/codesandbox-client/issues/134