### PR TITLE
Remove trailing comma all command line option from prettier githook

### DIFF
--- a/config/babel.dev.js
+++ b/config/babel.dev.js
@@ -8,7 +8,7 @@ module.exports = {
     // Latest stable ECMAScript features
     ['es2015', { modules: false }],
     // JSX, Flow
-    'react',
+    'react'
   ],
   plugins: [
     require.resolve('babel-plugin-transform-async-to-generator'),
@@ -22,9 +22,9 @@ module.exports = {
       require.resolve('react-loadable/babel'),
       {
         server: true,
-        webpack: true,
-      },
+        webpack: true
+      }
     ],
-    require.resolve('react-hot-loader/babel'),
-  ],
+    require.resolve('react-hot-loader/babel')
+  ]
 };

--- a/config/babel.prod.js
+++ b/config/babel.prod.js
@@ -7,7 +7,7 @@ module.exports = {
     // Latest stable ECMAScript features
     ['es2015', { modules: false }],
     // JSX, Flow
-    'react',
+    'react'
   ],
   plugins: [
     require.resolve('babel-plugin-transform-async-to-generator'),
@@ -21,14 +21,14 @@ module.exports = {
       require.resolve('react-loadable/babel'),
       {
         server: true,
-        webpack: true,
-      },
-    ],
+        webpack: true
+      }
+    ]
     // Optimization: hoist JSX that never changes out of render()
     // Disabled because of issues:
     // * https://github.com/facebookincubator/create-react-app/issues/525
     // * https://phabricator.babeljs.io/search/query/pCNlnC2xzwzx/
     // TODO: Enable again when these issues are resolved.
     // require.resolve('babel-plugin-transform-react-constant-elements')
-  ],
+  ]
 };

--- a/config/env.js
+++ b/config/env.js
@@ -25,6 +25,6 @@ module.exports = Object.keys(process.env)
     {
       'process.env.NODE_ENV': NODE_ENV,
       'process.env.CODESANDBOX_HOST': JSON.stringify(getHost()),
-      'process.env.LOCAL_SERVER': !!LOCAL_SERVER,
-    },
+      'process.env.LOCAL_SERVER': !!LOCAL_SERVER
+    }
   );

--- a/config/paths.js
+++ b/config/paths.js
@@ -38,5 +38,5 @@ module.exports = {
   embedSrc,
   appNodeModules: resolveApp('node_modules'),
   ownNodeModules: resolveApp('node_modules'),
-  nodePaths,
+  nodePaths
 };

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -35,7 +35,7 @@ const getOutput = () =>
         path: paths.appBuild,
         pathinfo: true,
         filename: 'static/js/[name].js',
-        publicPath,
+        publicPath
       }
     : {
         path: paths.appBuild,
@@ -43,7 +43,7 @@ const getOutput = () =>
         filename: 'static/js/[name].[chunkhash].js',
         chunkFilename: 'static/js/[name].[chunkhash].chunk.js',
         sourceMapFilename: '[file].map', // Default
-        publicPath,
+        publicPath
       };
 
 const config = {
@@ -54,13 +54,13 @@ const config = {
     sandbox: [
       require.resolve('babel-polyfill'),
       require.resolve('./polyfills'),
-      path.join(paths.sandboxSrc, 'index.js'),
+      path.join(paths.sandboxSrc, 'index.js')
     ],
     embed: [
       require.resolve('./polyfills'),
-      path.join(paths.embedSrc, 'index.js'),
+      path.join(paths.embedSrc, 'index.js')
     ],
-    vendor: ['react', 'react-dom', 'styled-components', 'babel-standalone'],
+    vendor: ['react', 'react-dom', 'styled-components', 'babel-standalone']
   },
 
   target: 'web',
@@ -68,7 +68,7 @@ const config = {
   node: {
     fs: 'empty',
     module: 'empty',
-    child_process: 'empty',
+    child_process: 'empty'
   },
 
   output: getOutput(),
@@ -77,12 +77,12 @@ const config = {
     rules: [
       {
         test: /create-zip\/.*\/files\/.*\.ico$/,
-        loader: 'base64-loader',
+        loader: 'base64-loader'
       },
       {
         test: /create-zip\/.*\/files\/.*$/,
         exclude: [/create-zip\/.*\/files\/.*\.ico$/],
-        loader: 'raw-loader',
+        loader: 'raw-loader'
       },
       {
         test: /\.js$/,
@@ -92,16 +92,16 @@ const config = {
           /typescriptServices\.js$/,
           // Don't do the node modules of the codesandbox module itself
           /codesandbox\/node_modules/,
-          /create-zip\/.*\/files\/.*$/,
+          /create-zip\/.*\/files\/.*$/
         ],
-        loader: 'happypack/loader',
+        loader: 'happypack/loader'
       },
       // JSON is not enabled by default in Webpack but both Node and Browserify
       // allow it implicitly so we also enable it.
       {
         test: /\.json$/,
         loader: 'json-loader',
-        exclude: [/create-zip\/.*\/files\/.*$/],
+        exclude: [/create-zip\/.*\/files\/.*$/]
       },
       // "postcss" loader applies autoprefixer to our CSS.
       // "css" loader resolves paths in CSS and adds assets as dependencies.
@@ -111,13 +111,13 @@ const config = {
       {
         test: /\.css$/,
         loaders: ['style-loader', 'css-loader'],
-        exclude: [/create-zip\/.*\/files\/.*$/],
+        exclude: [/create-zip\/.*\/files\/.*$/]
       },
       // For importing README.md
       {
         test: /\.md$/,
         loader: 'raw-loader',
-        exclude: [/create-zip\/.*\/files\/.*$/],
+        exclude: [/create-zip\/.*\/files\/.*$/]
       },
       // "file" loader makes sure those assets get served by WebpackDevServer.
       // When you `import` an asset, you get its (virtual) filename.
@@ -127,8 +127,8 @@ const config = {
         exclude: [/\/favicon.ico$/, /create-zip\/.*\/files\/.*$/],
         loader: 'file-loader',
         options: {
-          name: 'static/media/[name].[hash:8].[ext]',
-        },
+          name: 'static/media/[name].[hash:8].[ext]'
+        }
       },
       // A special case for favicon.ico to place it into build root directory.
       {
@@ -137,8 +137,8 @@ const config = {
         exclude: [/create-zip\/.*\/files\/.*$/],
         loader: 'file-loader',
         options: {
-          name: 'favicon.ico?[hash:8]',
-        },
+          name: 'favicon.ico?[hash:8]'
+        }
       },
       // "url" loader works just like "file" loader but it also embeds
       // assets smaller than specified size as data URLs to avoid requests.
@@ -148,8 +148,8 @@ const config = {
         exclude: [/create-zip\/.*\/files\/.*$/],
         options: {
           limit: 10000,
-          name: 'static/media/[name].[hash:8].[ext]',
-        },
+          name: 'static/media/[name].[hash:8].[ext]'
+        }
       },
       // "html" loader is used to process template page (index.html) to resolve
       // resources linked with <link href="./relative/path"> HTML tags.
@@ -158,12 +158,12 @@ const config = {
         loader: 'html-loader',
         exclude: [/create-zip\/.*\/files\/.*$/],
         options: {
-          attrs: ['link:href'],
-        },
-      },
+          attrs: ['link:href']
+        }
+      }
     ],
 
-    noParse: [/eslint\.4\.1\.0\.min\.js$/, /typescriptServices\.js$/],
+    noParse: [/eslint\.4\.1\.0\.min\.js$/, /typescriptServices\.js$/]
   },
 
   resolve: {
@@ -173,8 +173,8 @@ const config = {
     extensions: ['.js', '.json'],
 
     alias: {
-      moment: 'moment/moment.js',
-    },
+      moment: 'moment/moment.js'
+    }
   },
 
   plugins: [
@@ -182,9 +182,9 @@ const config = {
       loaders: [
         {
           path: 'babel-loader',
-          query: babelConfig,
-        },
-      ],
+          query: babelConfig
+        }
+      ]
     }),
     // Generates an `index.html` file with the <script> injected.
     new HtmlWebpackPlugin({
@@ -202,8 +202,8 @@ const config = {
         keepClosingSlash: true,
         minifyJS: true,
         minifyCSS: true,
-        minifyURLs: true,
-      },
+        minifyURLs: true
+      }
     }),
     new HtmlWebpackPlugin({
       inject: true,
@@ -220,8 +220,8 @@ const config = {
         keepClosingSlash: true,
         minifyJS: true,
         minifyCSS: true,
-        minifyURLs: true,
-      },
+        minifyURLs: true
+      }
     }),
     new HtmlWebpackPlugin({
       inject: true,
@@ -238,8 +238,8 @@ const config = {
         keepClosingSlash: true,
         minifyJS: true,
         minifyCSS: true,
-        minifyURLs: true,
-      },
+        minifyURLs: true
+      }
     }),
     // Makes some environment variables available to the JS code, for example:
     // if (process.env.NODE_ENV === 'development') { ... }. See `env.js`.
@@ -260,40 +260,40 @@ const config = {
         from: __DEV__
           ? 'node_modules/monaco-editor/dev/vs'
           : 'node_modules/monaco-editor/min/vs',
-        to: 'public/vs',
+        to: 'public/vs'
       },
       {
         from: 'static',
-        to: 'static',
+        to: 'static'
       },
       {
         from: 'src/homepage/static',
-        to: 'static',
-      },
+        to: 'static'
+      }
     ]),
     // Try to dedupe duplicated modules, if any:
     new webpack.optimize.CommonsChunkPlugin({
       name: 'common',
-      chunks: ['app', 'sandbox'],
+      chunks: ['app', 'sandbox']
     }),
     new webpack.optimize.CommonsChunkPlugin({
       name: 'vendor',
-      minChunks: Infinity,
+      minChunks: Infinity
     }),
     new webpack.optimize.CommonsChunkPlugin({
       async: true,
       children: true,
-      minChunks: 2,
+      minChunks: 2
     }),
-    new webpack.NamedModulesPlugin(),
-  ],
+    new webpack.NamedModulesPlugin()
+  ]
 };
 
 if (__DEV__) {
   const devEntries = [
     'react-hot-loader/patch',
     'webpack-dev-server/client?/',
-    'webpack/hot/only-dev-server',
+    'webpack/hot/only-dev-server'
   ];
 
   config.entry.app = [...devEntries, ...config.entry.app];
@@ -306,7 +306,7 @@ if (__PROD__) {
     // Minify the code.
     new webpack.LoaderOptionsPlugin({
       minimize: true,
-      debug: false,
+      debug: false
     }),
     new webpack.optimize.UglifyJsPlugin({
       beautify: false,
@@ -320,12 +320,12 @@ if (__PROD__) {
         dead_code: true,
         evaluate: true,
         if_return: true,
-        join_vars: true,
+        join_vars: true
       },
       output: {
-        comments: false,
+        comments: false
       },
-      sourceMap: true,
+      sourceMap: true
     }),
     // Generate a service worker script that will precache, and keep up to date,
     // the HTML & assets that are part of the Webpack build.
@@ -363,9 +363,9 @@ if (__PROD__) {
           options: {
             cache: {
               maxEntries: 50,
-              name: 'sandboxes-cache',
-            },
-          },
+              name: 'sandboxes-cache'
+            }
+          }
         },
         {
           urlPattern: /^https:\/\/unpkg\.com/,
@@ -373,9 +373,9 @@ if (__PROD__) {
           options: {
             cache: {
               maxEntries: 300,
-              name: 'unpkg-cache',
-            },
-          },
+              name: 'unpkg-cache'
+            }
+          }
         },
         {
           urlPattern: /cloudflare\.com/,
@@ -383,11 +383,11 @@ if (__PROD__) {
           options: {
             cache: {
               maxEntries: 20,
-              name: 'cloudflare-cache',
-            },
-          },
-        },
-      ],
+              name: 'cloudflare-cache'
+            }
+          }
+        }
+      ]
     }),
     // Generate a service worker script that will precache, and keep up to date,
     // the HTML & assets that are part of the Webpack build.
@@ -429,9 +429,9 @@ if (__PROD__) {
           options: {
             cache: {
               maxEntries: 50,
-              name: 'sandboxes-cache',
-            },
-          },
+              name: 'sandboxes-cache'
+            }
+          }
         },
         {
           // These should be dynamic, since it's not loaded from this domain
@@ -440,9 +440,9 @@ if (__PROD__) {
           handler: 'networkFirst',
           options: {
             cache: {
-              name: 'static-root-cache',
-            },
-          },
+              name: 'static-root-cache'
+            }
+          }
         },
         {
           urlPattern: /api\/v1\/sandboxes/,
@@ -450,9 +450,9 @@ if (__PROD__) {
           options: {
             cache: {
               maxEntries: 50,
-              name: 'sandboxes-cache',
-            },
-          },
+              name: 'sandboxes-cache'
+            }
+          }
         },
         {
           urlPattern: /\.amazonaws\.com\/prod\/package/,
@@ -461,9 +461,9 @@ if (__PROD__) {
             cache: {
               // a week
               maxAgeSeconds: 60 * 60 * 24 * 7,
-              name: 'dependency-url-generator-cache',
-            },
-          },
+              name: 'dependency-url-generator-cache'
+            }
+          }
         },
         {
           urlPattern: /webpack-dll-prod\.herokuapp\.com/,
@@ -471,9 +471,9 @@ if (__PROD__) {
           options: {
             cache: {
               maxEntries: 100,
-              name: 'packager-cache',
-            },
-          },
+              name: 'packager-cache'
+            }
+          }
         },
         {
           urlPattern: /https:\/\/d3i2v4dxqvxaq9\.cloudfront\.net/,
@@ -481,20 +481,20 @@ if (__PROD__) {
           options: {
             cache: {
               maxEntries: 200,
-              name: 'dependency-files-cache',
-            },
-          },
+              name: 'dependency-files-cache'
+            }
+          }
         },
         {
           urlPattern: /cloudflare\.com/,
           handler: 'cacheFirst',
           options: {
             cache: {
-              name: 'cloudflare-cache',
-            },
-          },
-        },
-      ],
+              name: 'cloudflare-cache'
+            }
+          }
+        }
+      ]
     }),
     // Moment.js is an extremely popular library that bundles large locale files
     // by default due to how Webpack interprets its code. This is a practical
@@ -502,12 +502,12 @@ if (__PROD__) {
     // https://github.com/jmblog/how-to-optimize-momentjs-with-webpack
     // You can remove this if you don't use Moment.js:
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
-    new webpack.optimize.ModuleConcatenationPlugin(),
+    new webpack.optimize.ModuleConcatenationPlugin()
   ];
 } else {
   config.plugins = [
     ...config.plugins,
-    new webpack.HotModuleReplacementPlugin(),
+    new webpack.HotModuleReplacementPlugin()
   ];
 }
 

--- a/package.json
+++ b/package.json
@@ -166,13 +166,16 @@
     "precommit": "lint-staged"
   },
   "lint-staged": {
-    "*.js": ["prettier --write --single-quote --trailing-comma all", "git add"],
+    "*.js": [
+      "prettier --write --single-quote --trailing-comma none",
+      "git add"
+    ],
     "*.css": [
-      "prettier --write --single-quote --trailing-comma all",
+      "prettier --write --single-quote --trailing-comma none",
       "git add"
     ],
     "*.json": [
-      "prettier --write --single-quote --trailing-comma all",
+      "prettier --write --single-quote --trailing-comma none",
       "git add"
     ]
   },

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -71,13 +71,13 @@ function printFileSizes(stats, previousSizeMap) {
         folder: path.join('build', path.dirname(asset.name)),
         name: path.basename(asset.name),
         size,
-        sizeLabel: filesize(size) + (difference ? ` (${difference})` : ''),
+        sizeLabel: filesize(size) + (difference ? ` (${difference})` : '')
       };
     });
   assets.sort((a, b) => b.size - a.size);
   let longestSizeLabelLength = Math.max.apply(
     null,
-    assets.map(a => stripAnsi(a.sizeLabel).length),
+    assets.map(a => stripAnsi(a.sizeLabel).length)
   );
   assets.forEach(asset => {
     let sizeLabel = asset.sizeLabel;
@@ -88,8 +88,8 @@ function printFileSizes(stats, previousSizeMap) {
     }
     console.log(
       `  ${sizeLabel}  ${chalk.dim(asset.folder + path.sep)}${chalk.cyan(
-        asset.name,
-      )}`,
+        asset.name
+      )}`
     );
   });
 }
@@ -99,7 +99,7 @@ function build(previousSizeMap) {
   console.log(
     `Creating a ${process.env.NODE_ENV === 'production'
       ? 'production'
-      : 'development'} build...`,
+      : 'development'} build...`
   );
   webpack(config).run((err, stats) => {
     if (err) {
@@ -116,7 +116,7 @@ function build(previousSizeMap) {
     printFileSizes(stats, previousSizeMap);
     fs.writeFile(
       paths.appBuild + '/stats.json',
-      JSON.stringify(stats.toJson()),
+      JSON.stringify(stats.toJson())
     );
     console.log();
 
@@ -127,13 +127,13 @@ function build(previousSizeMap) {
       // "homepage": "http://user.github.io/project"
       console.log(
         `The project was built assuming it is hosted at ${chalk.green(
-          publicPath,
-        )}.`,
+          publicPath
+        )}.`
       );
       console.log(
         `You can control this with the ${chalk.green(
-          'homepage',
-        )} field in your ${chalk.cyan('package.json')}.`,
+          'homepage'
+        )} field in your ${chalk.cyan('package.json')}.`
       );
       console.log();
       console.log(`The ${chalk.cyan('build')} folder is ready to be deployed.`);
@@ -141,20 +141,18 @@ function build(previousSizeMap) {
       console.log();
       console.log(
         `  ${chalk.cyan('git')} commit -am ${chalk.yellow(
-          '"Save local changes"',
-        )}`,
+          '"Save local changes"'
+        )}`
       );
       console.log(`  ${chalk.cyan('git')} checkout -B gh-pages`);
       console.log(`  ${chalk.cyan('git')} add -f build`);
       console.log(
-        `  ${chalk.cyan('git')} commit -am ${chalk.yellow(
-          '"Rebuild website"',
-        )}`,
+        `  ${chalk.cyan('git')} commit -am ${chalk.yellow('"Rebuild website"')}`
       );
       console.log(
         `  ${chalk.cyan(
-          'git',
-        )} filter-branch -f --prune-empty --subdirectory-filter build`,
+          'git'
+        )} filter-branch -f --prune-empty --subdirectory-filter build`
       );
       console.log(`  ${chalk.cyan('git')} push -f origin gh-pages`);
       console.log(`  ${chalk.cyan('git')} checkout -`);
@@ -163,13 +161,13 @@ function build(previousSizeMap) {
       // "homepage": "http://mywebsite.com/project"
       console.log(
         `The project was built assuming it is hosted at ${chalk.green(
-          publicPath,
-        )}.`,
+          publicPath
+        )}.`
       );
       console.log(
         `You can control this with the ${chalk.green(
-          'homepage',
-        )} field in your ${chalk.cyan('package.json')}.`,
+          'homepage'
+        )} field in your ${chalk.cyan('package.json')}.`
       );
       console.log();
       console.log(`The ${chalk.cyan('build')} folder is ready to be deployed.`);
@@ -177,29 +175,29 @@ function build(previousSizeMap) {
     } else {
       // no homepage or "homepage": "http://mywebsite.com"
       console.log(
-        'The project was built assuming it is hosted at the server root.',
+        'The project was built assuming it is hosted at the server root.'
       );
       if (homepagePath) {
         // "homepage": "http://mywebsite.com"
         console.log(
           `You can control this with the ${chalk.green(
-            'homepage',
-          )} field in your ${chalk.cyan('package.json')}.`,
+            'homepage'
+          )} field in your ${chalk.cyan('package.json')}.`
         );
         console.log();
       } else {
         // no homepage
         console.log(
           `To override this, specify the ${chalk.green(
-            'homepage',
-          )} in your ${chalk.cyan('package.json')}.`,
+            'homepage'
+          )} in your ${chalk.cyan('package.json')}.`
         );
         console.log('For example, add this to build it for GitHub Pages:');
         console.log();
         console.log(
           `  ${chalk.green('"homepage"')}${chalk.cyan(': ')}${chalk.green(
-            '"http://myname.github.io/myapp"',
-          )}${chalk.cyan(',')}`,
+            '"http://myname.github.io/myapp"'
+          )}${chalk.cyan(',')}`
         );
         console.log();
       }

--- a/scripts/utils/WatchMissingNodeModulesPlugin.js
+++ b/scripts/utils/WatchMissingNodeModulesPlugin.js
@@ -6,7 +6,7 @@ function WatchMissingNodeModulesPlugin(nodeModulesPath) {
   this.nodeModulesPath = nodeModulesPath;
 }
 
-WatchMissingNodeModulesPlugin.prototype.apply = function (compiler) {
+WatchMissingNodeModulesPlugin.prototype.apply = function(compiler) {
   compiler.plugin('emit', (compilation, callback) => {
     var missingDeps = compilation.missingDependencies;
     var nodeModulesPath = this.nodeModulesPath;
@@ -19,6 +19,6 @@ WatchMissingNodeModulesPlugin.prototype.apply = function (compiler) {
 
     callback();
   });
-}
+};
 
 module.exports = WatchMissingNodeModulesPlugin;

--- a/scripts/utils/prompt.js
+++ b/scripts/utils/prompt.js
@@ -3,14 +3,16 @@ var rl = require('readline');
 // Convention: "no" should be the conservative choice.
 // If you mistype the answer, we'll always take it as a "no".
 // You can control the behavior on <Enter> with `isYesDefault`.
-module.exports = function (question, isYesDefault) {
+module.exports = function(question, isYesDefault) {
   if (typeof isYesDefault !== 'boolean') {
-    throw new Error('Provide explicit boolean isYesDefault as second argument.');
+    throw new Error(
+      'Provide explicit boolean isYesDefault as second argument.'
+    );
   }
   return new Promise(resolve => {
     var rlInterface = rl.createInterface({
       input: process.stdin,
-      output: process.stdout,
+      output: process.stdout
     });
 
     var hint = isYesDefault === true ? '[Y/n]' : '[y/N]';


### PR DESCRIPTION
Previous issue to remove trailing comma rule so that versions before node 8 could be supported was not properly resolved as the git hook still ran prettier with the `--trailing-comma all` command line options.

This PR fixes those options and removes trailing commas from files that are run with node.