### PR TITLE
Add animation when sub-modes disappear in the header

### DIFF
--- a/src/app/components/sandbox/ModeIcons.js
+++ b/src/app/components/sandbox/ModeIcons.js
@@ -157,9 +157,18 @@ const getCurrentMode = ({
 };
 
 export default class ModeIcons extends React.PureComponent<Props> {
-  state = {
-    hovering: false
-  };
+  constructor(props) {
+    super(props);
+
+    const { currentMode, otherModes } = getCurrentMode(this.props);
+
+    this.state = {
+      hovering: false,
+      showSubmodes: false,
+      currentMode,
+      otherModes
+    };
+  }
 
   onMouseEnter = () => {
     this.setState({
@@ -175,12 +184,31 @@ export default class ModeIcons extends React.PureComponent<Props> {
   };
 
   onAnimationEnd = () => {
+    const { currentMode, otherModes } = getCurrentMode(this.props);
+
     if (!this.state.hovering) {
       this.setState({
-        showSubmodes: false
+        showSubmodes: false,
+        currentMode,
+        otherModes
       });
     }
   };
+
+  componentWillReceiveProps(nextProps) {
+    const { currentMode, otherModes } = getCurrentMode(nextProps);
+
+    if (!this.state.hovering) {
+      this.setState({
+        currentMode,
+        otherModes
+      });
+    } else {
+      this.setState({
+        currentMode
+      });
+    }
+  }
 
   render() {
     const {
@@ -192,17 +220,17 @@ export default class ModeIcons extends React.PureComponent<Props> {
       dropdown
     } = this.props;
 
-    if (dropdown) {
-      const { currentMode, otherModes } = getCurrentMode(this.props);
+    const { hovering, showSubmodes, currentMode, otherModes } = this.state;
 
+    if (dropdown) {
       return (
         <Tooltips>
           <Hover onMouseLeave={this.onMouseLeave}>
-            {this.state.showSubmodes &&
+            {showSubmodes &&
               <SubMode
                 onClick={this.onMouseLeave}
                 onAnimationEnd={this.onAnimationEnd}
-                hovering={this.state.hovering}
+                hovering={hovering}
                 i={0}
               >
                 {otherModes[0]}
@@ -210,11 +238,11 @@ export default class ModeIcons extends React.PureComponent<Props> {
             <div onMouseEnter={this.onMouseEnter}>
               {currentMode}
             </div>
-            {this.state.showSubmodes &&
+            {showSubmodes &&
               <SubMode
                 onClick={this.onMouseLeave}
                 onAnimationEnd={this.onAnimationEnd}
-                hovering={this.state.hovering}
+                hovering={hovering}
                 i={1}
               >
                 {otherModes[1]}

--- a/src/app/components/sandbox/ModeIcons.js
+++ b/src/app/components/sandbox/ModeIcons.js
@@ -3,22 +3,44 @@ import styled, { keyframes } from 'styled-components';
 
 import Tooltip from 'app/components/Tooltip';
 
-const animation = keyframes`
+const showAnimationKeyframes = keyframes`
   0%   { opacity: 0; transform: translateX(10px); }
   100% { opacity: 1; transform: translateX(0px); }
 `;
 
-const reverseAnimation = keyframes`
+const reverseShowAnimationKeyframes = keyframes`
   0%   { opacity: 0; transform: translateX(-10px); }
   100% { opacity: 1; transform: translateX(0px); }
 `;
 
-const delayAnimation = (delay: number = 0, reverse: boolean = true) =>
+const showAnimation = (delay: number = 0, reverse: boolean = true) =>
   `
-    animation: ${reverse ? reverseAnimation : animation} 0.3s;
+    animation: ${reverse
+      ? reverseShowAnimationKeyframes
+      : showAnimationKeyframes} 0.3s;
     animation-delay: ${delay}s;
     animation-fill-mode: forwards;
     opacity: 0;
+  `;
+
+const hideAnimationKeyframes = keyframes`
+  0%   { opacity: 1; transform: translateX(0px); }
+  100% { opacity: 0; transform: translateX(10px); }
+`;
+
+const reverseHideAnimationKeyframes = keyframes`
+  0%   { opacity: 1; transform: translateX(0px); }
+  100% { opacity: 0; transform: translateX(-10px); }
+`;
+
+const hideAnimation = (delay: number = 0, reverse: boolean = true) =>
+  `
+    animation: ${reverse
+      ? reverseHideAnimationKeyframes
+      : hideAnimationKeyframes} 0.3s;
+    animation-delay: ${delay}s;
+    animation-fill-mode: forwards;
+    opacity: 1;
   `;
 
 const Tooltips = styled.div`
@@ -69,7 +91,10 @@ const Hover = styled.div`
 `;
 
 const SubMode = styled.div`
-  ${props => delayAnimation(props.i * 0.05, props.i === 1)};
+  ${props =>
+    props.hovering
+      ? showAnimation(props.i * 0.05, props.i === 1)
+      : hideAnimation(props.i * 0.05, props.i === 1)};
 `;
 
 const Icon = styled.div`
@@ -94,7 +119,7 @@ type Props = {
   setEditorView: () => void,
   setPreviewView: () => void,
   setMixedView: () => void,
-  noPreview: ?boolean,
+  noPreview: ?boolean
 };
 
 const getCurrentMode = ({
@@ -102,7 +127,7 @@ const getCurrentMode = ({
   showPreview,
   setMixedView,
   setEditorView,
-  setPreviewView,
+  setPreviewView
 }: Props) => {
   const both = (
     <ViewIcon onClick={setMixedView} active={showEditor && showPreview}>
@@ -133,19 +158,28 @@ const getCurrentMode = ({
 
 export default class ModeIcons extends React.PureComponent<Props> {
   state = {
-    hovering: false,
+    hovering: false
   };
 
   onMouseEnter = () => {
     this.setState({
-      hovering: true,
+      showSubmodes: true,
+      hovering: true
     });
   };
 
   onMouseLeave = () => {
     this.setState({
-      hovering: false,
+      hovering: false
     });
+  };
+
+  onAnimationEnd = () => {
+    if (!this.state.hovering) {
+      this.setState({
+        showSubmodes: false
+      });
+    }
   };
 
   render() {
@@ -155,7 +189,7 @@ export default class ModeIcons extends React.PureComponent<Props> {
       setEditorView,
       setMixedView,
       setPreviewView,
-      dropdown,
+      dropdown
     } = this.props;
 
     if (dropdown) {
@@ -164,9 +198,10 @@ export default class ModeIcons extends React.PureComponent<Props> {
       return (
         <Tooltips>
           <Hover onMouseLeave={this.onMouseLeave}>
-            {this.state.hovering &&
+            {this.state.showSubmodes &&
               <SubMode
                 onClick={this.onMouseLeave}
+                onAnimationEnd={this.onAnimationEnd}
                 hovering={this.state.hovering}
                 i={0}
               >
@@ -175,9 +210,10 @@ export default class ModeIcons extends React.PureComponent<Props> {
             <div onMouseEnter={this.onMouseEnter}>
               {currentMode}
             </div>
-            {this.state.hovering &&
+            {this.state.showSubmodes &&
               <SubMode
                 onClick={this.onMouseLeave}
+                onAnimationEnd={this.onAnimationEnd}
                 hovering={this.state.hovering}
                 i={1}
               >


### PR DESCRIPTION
One of the things which I absolutely like about Code Sandbox is that it has a lot of fast smooth transitions in the UI. Actually, I have found inspiration from your work and applied to it to my own works, so thanks for that! 😄 

One small thing disturbed me though. There's a very nice animation when hovering over the current mode to show the sub-modes, but there is no "leaving" animation:

![current_sub_modes](https://user-images.githubusercontent.com/9586897/29688540-cd6d63c6-8928-11e7-90fd-5ee12bb5644b.gif)

I tried adding a leaving animation (first commit). It wasn't that hard, and worked fine initially:

![updated_sub_modes](https://user-images.githubusercontent.com/9586897/29688562-dd844518-8928-11e7-9652-7c448ba7bc47.gif)

However, I quickly discovered a nasty side effect: the mode changes instantly, so when clicking a mode, it looks a bit weird:

![side_effect_sub_modes](https://user-images.githubusercontent.com/9586897/29688590-f4647758-8928-11e7-8717-ebec3fc5a132.gif)

I tried two things:

- Only changing all the modes after the animation ended; didn't work out so well because the selected mode would switch when animation ends, which looked odd
- Change the selected mode initially, but only swap the sub-modes after the animation ended. This worked out quite nice:

![final_solution_sub_modes](https://user-images.githubusercontent.com/9586897/29688633-1c04b822-8929-11e7-8092-e0728ce5a074.gif)

I think I understood why there was no animation (yet?) as it wasn't easy to find something that works nicely. But I think the above approach works quite well and looks quite nice. I don't know if this is something you want, but if you do feel free. It was at least fun to look into this. 😄 


