### PR TITLE
Introduce delete file modal

### DIFF
--- a/src/app/components/Alert.js
+++ b/src/app/components/Alert.js
@@ -45,7 +45,7 @@ type Props = {
   onDelete: Function
 };
 
-const DeleteFile = ({ title, body, onCancel, onDelete }: Props) =>
+const Alert = ({ title, body, onCancel, onDelete }: Props) =>
   <Container>
     <Title>
       {title}
@@ -65,4 +65,4 @@ const DeleteFile = ({ title, body, onCancel, onDelete }: Props) =>
     </Buttons>
   </Container>;
 
-export default DeleteFile;
+export default Alert;

--- a/src/app/components/Alert.js
+++ b/src/app/components/Alert.js
@@ -1,6 +1,6 @@
-import React from "react";
-import styled from "styled-components";
-import Button from "app/components/buttons/Button";
+import React from 'react';
+import styled from 'styled-components';
+import Button from 'app/components/buttons/Button';
 
 const Container = styled.div`
   display: flex;
@@ -42,18 +42,14 @@ type Props = {
   title: string,
   body: string | Object,
   onCancel: Function,
-  onDelete: Function
+  onDelete: Function,
 };
 
-const Alert = ({ title, body, onCancel, onDelete }: Props) =>
+const Alert = ({ title, body, onCancel, onDelete }: Props) => (
   <Container>
-    <Title>
-      {title}
-    </Title>
+    <Title>{title}</Title>
 
-    <Text>
-      {body}
-    </Text>
+    <Text>{body}</Text>
 
     <Buttons>
       <Button small block secondary onClick={onCancel}>
@@ -63,6 +59,7 @@ const Alert = ({ title, body, onCancel, onDelete }: Props) =>
         Delete
       </Button>
     </Buttons>
-  </Container>;
+  </Container>
+);
 
 export default Alert;

--- a/src/app/components/buttons/Button.js
+++ b/src/app/components/buttons/Button.js
@@ -1,19 +1,26 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
-import styled, { css, keyframes } from 'styled-components';
+import React from "react";
+import { Link } from "react-router-dom";
+import styled, { css, keyframes } from "styled-components";
 
-import theme from 'common/theme';
+import theme from "common/theme";
 
-const getBackgroundColor = ({ disabled, red }) => {
+const getBackgroundColor = ({ disabled, red, secondary }) => {
   if (disabled) return `background: ${theme.background2.darken(0.1)()}`;
+  if (secondary) return `background: #3A4B5D`;
   if (red)
     return `background-image: linear-gradient(270deg, #F27777, #400000);`;
   return `background-image: linear-gradient(270deg, #fed29d, #A58B66, #7abae8, #56a0d6);`;
 };
 
-const getColor = ({ disabled }) => {
+const getColor = ({ disabled, secondary }) => {
   if (disabled) return theme.background2.lighten(1.5)();
-  return 'white';
+  if (secondary) return `#56a0d6`;
+  return "white";
+};
+
+const getBorder = ({ secondary }) => {
+  if (secondary) return `1px solid #56a0d6`;
+  return "none";
 };
 
 const forward = keyframes`
@@ -37,6 +44,7 @@ const styles = css`
   ${props => getBackgroundColor(props)};
   background-size: 720%;
 
+  border:${props => getBorder(props)};
   border-radius: 4px;
 
   box-sizing: border-box;
@@ -45,7 +53,7 @@ const styles = css`
   color: ${props => getColor(props)};
   font-weight: 400;
   ${props => !props.disabled && `box-shadow: 0 3px 3px rgba(0, 0, 0, 0.5);`};
-  width: ${props => (props.block ? '100%' : 'inherit')};
+  width: ${props => (props.block ? "100%" : "inherit")};
 
   ${props => () => {
     if (props.small) {
@@ -54,7 +62,7 @@ const styles = css`
         font-size: 0.875rem;
       `;
     }
-    return 'padding: 0.65rem 2.25rem;';
+    return "padding: 0.65rem 2.25rem;";
   }} user-select: none;
   text-decoration: none;
 
@@ -85,7 +93,7 @@ const Button = styled.button`${styles};`;
 type Props = {
   [key: any]: any,
   to: ?string,
-  href: ?string,
+  href: ?string
 };
 
 export default (props: Props) => {

--- a/src/app/components/buttons/Button.js
+++ b/src/app/components/buttons/Button.js
@@ -1,8 +1,8 @@
-import React from "react";
-import { Link } from "react-router-dom";
-import styled, { css, keyframes } from "styled-components";
+import React from 'react';
+import { Link } from 'react-router-dom';
+import styled, { css, keyframes } from 'styled-components';
 
-import theme from "common/theme";
+import theme from 'common/theme';
 
 const getBackgroundColor = ({ disabled, red, secondary }) => {
   if (disabled) return `background: ${theme.background2.darken(0.1)()}`;
@@ -15,12 +15,12 @@ const getBackgroundColor = ({ disabled, red, secondary }) => {
 const getColor = ({ disabled, secondary }) => {
   if (disabled) return theme.background2.lighten(1.5)();
   if (secondary) return `#56a0d6`;
-  return "white";
+  return 'white';
 };
 
 const getBorder = ({ secondary }) => {
   if (secondary) return `1px solid #56a0d6`;
-  return "none";
+  return 'none';
 };
 
 const forward = keyframes`
@@ -44,7 +44,7 @@ const styles = css`
   ${props => getBackgroundColor(props)};
   background-size: 720%;
 
-  border:${props => getBorder(props)};
+  border: ${props => getBorder(props)};
   border-radius: 4px;
 
   box-sizing: border-box;
@@ -53,7 +53,7 @@ const styles = css`
   color: ${props => getColor(props)};
   font-weight: 400;
   ${props => !props.disabled && `box-shadow: 0 3px 3px rgba(0, 0, 0, 0.5);`};
-  width: ${props => (props.block ? "100%" : "inherit")};
+  width: ${props => (props.block ? '100%' : 'inherit')};
 
   ${props => () => {
     if (props.small) {
@@ -62,7 +62,7 @@ const styles = css`
         font-size: 0.875rem;
       `;
     }
-    return "padding: 0.65rem 2.25rem;";
+    return 'padding: 0.65rem 2.25rem;';
   }} user-select: none;
   text-decoration: none;
 
@@ -93,7 +93,7 @@ const Button = styled.button`${styles};`;
 type Props = {
   [key: any]: any,
   to: ?string,
-  href: ?string
+  href: ?string,
 };
 
 export default (props: Props) => {

--- a/src/app/components/buttons/Button.test.js
+++ b/src/app/components/buttons/Button.test.js
@@ -1,18 +1,18 @@
-import React from "react";
-import testRender from "app/utils/test/render";
-import { MemoryRouter } from "react-router-dom";
-import Button from "./Button";
+import React from 'react';
+import testRender from 'app/utils/test/render';
+import { MemoryRouter } from 'react-router-dom';
+import Button from './Button';
 
-describe("Button", () => {
-  it("renders", () => {
+describe('Button', () => {
+  it('renders', () => {
     testRender(<Button>Test</Button>);
   });
 
-  it("renders onClick", () => {
+  it('renders onClick', () => {
     testRender(<Button onClick={() => {}}>Test</Button>);
   });
 
-  it("renders to", () => {
+  it('renders to', () => {
     testRender(
       <MemoryRouter>
         <Button to="https://ivesvh.com">Test</Button>
@@ -20,19 +20,19 @@ describe("Button", () => {
     );
   });
 
-  it("renders href", () => {
+  it('renders href', () => {
     testRender(<Button href="https://ivesvh.com">Test</Button>);
   });
 
-  it("renders properties", () => {
+  it('renders properties', () => {
     testRender(<Button small>Test</Button>);
   });
 
-  it("renders disabled", () => {
+  it('renders disabled', () => {
     testRender(<Button disabled>Test</Button>);
   });
 
-  it("renders secondary", () => {
+  it('renders secondary', () => {
     testRender(<Button secondary>Test</Button>);
   });
 });

--- a/src/app/components/buttons/Button.test.js
+++ b/src/app/components/buttons/Button.test.js
@@ -1,18 +1,18 @@
-import React from 'react';
-import testRender from 'app/utils/test/render';
-import { MemoryRouter } from 'react-router-dom';
-import Button from './Button';
+import React from "react";
+import testRender from "app/utils/test/render";
+import { MemoryRouter } from "react-router-dom";
+import Button from "./Button";
 
-describe('Button', () => {
-  it('renders', () => {
+describe("Button", () => {
+  it("renders", () => {
     testRender(<Button>Test</Button>);
   });
 
-  it('renders onClick', () => {
+  it("renders onClick", () => {
     testRender(<Button onClick={() => {}}>Test</Button>);
   });
 
-  it('renders to', () => {
+  it("renders to", () => {
     testRender(
       <MemoryRouter>
         <Button to="https://ivesvh.com">Test</Button>
@@ -20,15 +20,19 @@ describe('Button', () => {
     );
   });
 
-  it('renders href', () => {
+  it("renders href", () => {
     testRender(<Button href="https://ivesvh.com">Test</Button>);
   });
 
-  it('renders properties', () => {
+  it("renders properties", () => {
     testRender(<Button small>Test</Button>);
   });
 
-  it('renders disabled', () => {
+  it("renders disabled", () => {
     testRender(<Button disabled>Test</Button>);
+  });
+
+  it("renders secondary", () => {
+    testRender(<Button secondary>Test</Button>);
   });
 });

--- a/src/app/components/buttons/__snapshots__/Button.test.js.snap
+++ b/src/app/components/buttons/__snapshots__/Button.test.js.snap
@@ -14,6 +14,7 @@ exports[`Button renders 1`] = `
   outline: none;
   background-image: linear-gradient(270deg,#fed29d,#A58B66,#7abae8,#56a0d6);
   background-size: 720%;
+  border: none;
   border-radius: 4px;
   box-sizing: border-box;
   font-size: 1.125rem;
@@ -76,6 +77,7 @@ exports[`Button renders disabled 1`] = `
   outline: none;
   background: rgb(25,29,31);
   background-size: 720%;
+  border: none;
   border-radius: 4px;
   box-sizing: border-box;
   font-size: 1.125rem;
@@ -113,6 +115,7 @@ exports[`Button renders href 1`] = `
   outline: none;
   background-image: linear-gradient(270deg,#fed29d,#A58B66,#7abae8,#56a0d6);
   background-size: 720%;
+  border: none;
   border-radius: 4px;
   box-sizing: border-box;
   font-size: 1.125rem;
@@ -176,6 +179,7 @@ exports[`Button renders onClick 1`] = `
   outline: none;
   background-image: linear-gradient(270deg,#fed29d,#A58B66,#7abae8,#56a0d6);
   background-size: 720%;
+  border: none;
   border-radius: 4px;
   box-sizing: border-box;
   font-size: 1.125rem;
@@ -239,6 +243,7 @@ exports[`Button renders properties 1`] = `
   outline: none;
   background-image: linear-gradient(270deg,#fed29d,#A58B66,#7abae8,#56a0d6);
   background-size: 720%;
+  border: none;
   border-radius: 4px;
   box-sizing: border-box;
   font-size: 1.125rem;
@@ -249,6 +254,69 @@ exports[`Button renders properties 1`] = `
   width: inherit;
   padding: 0.5rem 0.75rem;
   font-size: 0.875rem;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.c0:hover {
+  -webkit-animation-name: eEnBCQ;
+  animation-name: eEnBCQ;
+  -webkit-animation-duration: 300ms;
+  animation-duration: 300ms;
+  -webkit-animation-timing-function: ease;
+  animation-timing-function: ease;
+  -webkit-animation-direction: normal;
+  animation-direction: normal;
+  -webkit-animation-fill-mode: forwards;
+  animation-fill-mode: forwards;
+  box-shadow: 0 7px 10px rgba(0,0,0,0.5);
+  -webkit-transform: translateY(-1px);
+  -ms-transform: translateY(-1px);
+  transform: translateY(-1px);
+}
+
+.c0:active {
+  -webkit-transform: translateY(1px);
+  -ms-transform: translateY(1px);
+  transform: translateY(1px);
+  box-shadow: 0 0 0 rgba(0,0,0,0.5);
+}
+
+<button
+  className="c0"
+>
+  Test
+</button>
+`;
+
+exports[`Button renders secondary 1`] = `
+.c0 {
+  -webkit-transition: 0.3s ease all;
+  transition: 0.3s ease all;
+  -webkit-animation-name: cUPaoU;
+  animation-name: cUPaoU;
+  -webkit-animation-duration: 300ms;
+  animation-duration: 300ms;
+  -webkit-animation-timing-function: ease;
+  animation-timing-function: ease;
+  border: none;
+  outline: none;
+  background: #3A4B5D;
+  background-size: 720%;
+  border: 1px solid #56a0d6;
+  border-radius: 4px;
+  box-sizing: border-box;
+  font-size: 1.125rem;
+  text-align: center;
+  color: #56a0d6;
+  font-weight: 400;
+  box-shadow: 0 3px 3px rgba(0,0,0,0.5);
+  width: inherit;
+  padding: 0.65rem 2.25rem;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -302,6 +370,7 @@ exports[`Button renders to 1`] = `
   outline: none;
   background-image: linear-gradient(270deg,#fed29d,#A58B66,#7abae8,#56a0d6);
   background-size: 720%;
+  border: none;
   border-radius: 4px;
   box-sizing: border-box;
   font-size: 1.125rem;

--- a/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/DeleteFile.js
+++ b/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/DeleteFile.js
@@ -39,18 +39,20 @@ const Buttons = styled.div`
 `;
 
 type Props = {
-  filename: string,
+  title: string,
+  body: string | Object,
   onCancel: Function,
   onDelete: Function
 };
 
-const DeleteFile = ({ filename, onCancel, onDelete }: Props) =>
+const DeleteFile = ({ title, body, onCancel, onDelete }: Props) =>
   <Container>
-    <Title>Delete</Title>
+    <Title>
+      {title}
+    </Title>
 
     <Text>
-      Are you sure you want to delete <b>{filename}</b>? The file will be
-      permanently removed.
+      {body}
     </Text>
 
     <Buttons>

--- a/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/DeleteFile.js
+++ b/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/DeleteFile.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import styled from 'styled-components';
+import Button from 'app/components/buttons/Button';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  background-color: ${props => props.theme.background};
+  color: rgba(255, 255, 255, 0.8);
+  padding: 0.75rem;
+`;
+
+const Title = styled.div`
+  display: flex;
+  justify-content: center;
+  font-weight: 500;
+  font-size: 1.125rem;
+  color: rgba(255, 255, 255, 0.9);
+  margin-top: 0 !important;
+  margin-bottom: 1rem;
+  text-transform: uppercase;
+`;
+
+const Text = styled.div`
+  font-size: 14px;
+  font-weight: 0;
+`;
+
+const Buttons = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 1rem;
+  button {
+    display: flex;
+    justify-content: center;
+    width: 6rem;
+    margin: 0.5rem;
+  }
+`;
+
+type Props = {
+  filename: string,
+  onCancel: Function,
+  onDelete: Function
+};
+
+const DeleteFile = ({ filename, onCancel, onDelete }: Props) =>
+  <Container>
+    <Title>Delete</Title>
+
+    <Text>
+      Are you sure you want to delete <b>{filename}</b>? The file will be
+      permanently removed.
+    </Text>
+
+    <Buttons>
+      <Button small block onClick={onCancel}>
+        Cancel
+      </Button>
+      <Button small block red onClick={onDelete}>
+        Delete
+      </Button>
+    </Buttons>
+  </Container>;
+
+export default DeleteFile;

--- a/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/DeleteFile.js
+++ b/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/DeleteFile.js
@@ -1,6 +1,6 @@
-import React from 'react';
-import styled from 'styled-components';
-import Button from 'app/components/buttons/Button';
+import React from "react";
+import styled from "styled-components";
+import Button from "app/components/buttons/Button";
 
 const Container = styled.div`
   display: flex;
@@ -54,10 +54,10 @@ const DeleteFile = ({ filename, onCancel, onDelete }: Props) =>
     </Text>
 
     <Buttons>
-      <Button small block onClick={onCancel}>
+      <Button small block secondary onClick={onCancel}>
         Cancel
       </Button>
-      <Button small block red onClick={onDelete}>
+      <Button small block primary onClick={onDelete}>
         Delete
       </Button>
     </Buttons>

--- a/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/index.js
+++ b/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/index.js
@@ -1,20 +1,20 @@
-import React from "react";
-import styled from "styled-components";
-import { connect } from "react-redux";
-import { bindActionCreators } from "redux";
-import { DropTarget } from "react-dnd";
+import React from 'react';
+import styled from 'styled-components';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { DropTarget } from 'react-dnd';
 
-import type { Module, Directory } from "common/types";
+import type { Module, Directory } from 'common/types';
 
-import sandboxActionCreators from "app/store/entities/sandboxes/actions";
-import { validateTitle } from "app/store/entities//sandboxes/modules/validator";
-import contextMenuActionCreators from "app/store/context-menu/actions";
-import { getModuleParents } from "app/store/entities/sandboxes/modules/selectors";
-import modalActionCreators from "app/store/modal/actions";
-import Alert from "app/components/Alert";
+import sandboxActionCreators from 'app/store/entities/sandboxes/actions';
+import { validateTitle } from 'app/store/entities//sandboxes/modules/validator';
+import contextMenuActionCreators from 'app/store/context-menu/actions';
+import { getModuleParents } from 'app/store/entities/sandboxes/modules/selectors';
+import modalActionCreators from 'app/store/modal/actions';
+import Alert from 'app/components/Alert';
 
-import Entry from "./Entry";
-import DirectoryChildren from "./DirectoryChildren";
+import Entry from './Entry';
+import DirectoryChildren from './DirectoryChildren';
 
 const EntryContainer = styled.div`position: relative;`;
 
@@ -25,18 +25,18 @@ const Overlay = styled.div`
   left: 0;
   right: 0;
   background-color: rgba(0, 0, 0, 0.3);
-  display: ${props => (props.isOver ? "block" : "none")};
+  display: ${props => (props.isOver ? 'block' : 'none')};
 `;
 
 const Opener = styled.div`
-  height: ${props => (props.open ? "100%" : "0px")};
+  height: ${props => (props.open ? '100%' : '0px')};
   overflow: hidden;
 `;
 
 const mapDispatchToProps = dispatch => ({
   sandboxActions: bindActionCreators(sandboxActionCreators, dispatch),
   openMenu: bindActionCreators(contextMenuActionCreators, dispatch).openMenu,
-  modalActions: bindActionCreators(modalActionCreators, dispatch)
+  modalActions: bindActionCreators(modalActionCreators, dispatch),
 });
 type Props = {
   id: string,
@@ -54,10 +54,10 @@ type Props = {
   sandboxActions: typeof sandboxActionCreators,
   modalActions: typeof modalActionCreators,
   currentModuleId: ?string,
-  isInProjectView: boolean
+  isInProjectView: boolean,
 };
 type State = {
-  creating: "" | "module" | "directory"
+  creating: '' | 'module' | 'directory',
 };
 class DirectoryEntry extends React.PureComponent {
   props: Props;
@@ -76,8 +76,8 @@ class DirectoryEntry extends React.PureComponent {
     const isParentOfModule = currentModuleParents.includes(id);
 
     this.state = {
-      creating: "",
-      open: props.root || isParentOfModule
+      creating: '',
+      open: props.root || isParentOfModule,
     };
   }
 
@@ -100,12 +100,12 @@ class DirectoryEntry extends React.PureComponent {
     }
   }
 
-  resetState = () => this.setState({ creating: "" });
+  resetState = () => this.setState({ creating: '' });
 
   onCreateModuleClick = () => {
     this.setState({
-      creating: "module",
-      open: true
+      creating: 'module',
+      open: true,
     });
     return true;
   };
@@ -142,14 +142,14 @@ class DirectoryEntry extends React.PureComponent {
             sandboxActions.deleteModule(sandboxId, id);
           }}
         />
-      )
+      ),
     });
   };
 
   onCreateDirectoryClick = () => {
     this.setState({
-      creating: "directory",
-      open: true
+      creating: 'directory',
+      open: true,
     });
     return true;
   };
@@ -199,7 +199,7 @@ class DirectoryEntry extends React.PureComponent {
 
     return [
       ...modules.filter(m => m.directoryShortid === shortid),
-      ...directories.filter(d => d.directoryShortid === shortid)
+      ...directories.filter(d => d.directoryShortid === shortid),
     ];
   };
 
@@ -222,12 +222,12 @@ class DirectoryEntry extends React.PureComponent {
       isOver, // eslint-disable-line
       isInProjectView,
       depth = 0,
-      root
+      root,
     } = this.props;
     const { creating, open } = this.state;
 
     return connectDropTarget(
-      <div style={{ position: "relative" }}>
+      <div style={{ position: 'relative' }}>
         <Overlay isOver={isOver} />
         <EntryContainer>
           <Entry
@@ -249,7 +249,7 @@ class DirectoryEntry extends React.PureComponent {
           />
         </EntryContainer>
         <Opener open={open}>
-          {creating === "directory" &&
+          {creating === 'directory' && (
             <Entry
               id=""
               title=""
@@ -259,7 +259,8 @@ class DirectoryEntry extends React.PureComponent {
               renameValidator={this.validateModuleTitle}
               rename={this.createDirectory}
               onRenameCancel={this.resetState}
-            />}
+            />
+          )}
           <DirectoryChildren
             modules={modules}
             directories={directories}
@@ -273,7 +274,7 @@ class DirectoryEntry extends React.PureComponent {
             currentModuleId={currentModuleId}
             isInProjectView={isInProjectView}
           />
-          {creating === "module" &&
+          {creating === 'module' && (
             <Entry
               id=""
               title=""
@@ -282,7 +283,8 @@ class DirectoryEntry extends React.PureComponent {
               renameValidator={this.validateModuleTitle}
               rename={this.createModule}
               onRenameCancel={this.resetState}
-            />}
+            />
+          )}
         </Opener>
       </div>
     );
@@ -320,7 +322,7 @@ const entryTarget = {
 
     if (source.id === props.id) return false;
     return true;
-  }
+  },
 };
 
 function collectTarget(connectMonitor, monitor) {
@@ -331,10 +333,10 @@ function collectTarget(connectMonitor, monitor) {
     // You can ask the monitor about the current drag state:
     isOver: monitor.isOver({ shallow: true }),
     canDrop: monitor.canDrop(),
-    itemType: monitor.getItemType()
+    itemType: monitor.getItemType(),
   };
 }
 
 export default connect(null, mapDispatchToProps)(
-  DropTarget("ENTRY", entryTarget, collectTarget)(DirectoryEntry)
+  DropTarget('ENTRY', entryTarget, collectTarget)(DirectoryEntry)
 );

--- a/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/index.js
+++ b/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/index.js
@@ -11,10 +11,10 @@ import { validateTitle } from "app/store/entities//sandboxes/modules/validator";
 import contextMenuActionCreators from "app/store/context-menu/actions";
 import { getModuleParents } from "app/store/entities/sandboxes/modules/selectors";
 import modalActionCreators from "app/store/modal/actions";
+import Alert from "app/components/Alert";
 
 import Entry from "./Entry";
 import DirectoryChildren from "./DirectoryChildren";
-import DeleteFile from "./DeleteFile";
 
 const EntryContainer = styled.div`position: relative;`;
 
@@ -127,7 +127,7 @@ class DirectoryEntry extends React.PureComponent {
 
     modalActions.openModal({
       Body: (
-        <DeleteFile
+        <Alert
           title="Delete File"
           body={
             <span>

--- a/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/index.js
+++ b/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/index.js
@@ -10,9 +10,11 @@ import sandboxActionCreators from 'app/store/entities/sandboxes/actions';
 import { validateTitle } from 'app/store/entities//sandboxes/modules/validator';
 import contextMenuActionCreators from 'app/store/context-menu/actions';
 import { getModuleParents } from 'app/store/entities/sandboxes/modules/selectors';
+import modalActionCreators from 'app/store/modal/actions';
 
 import Entry from './Entry';
 import DirectoryChildren from './DirectoryChildren';
+import DeleteFile from './DeleteFile';
 
 const EntryContainer = styled.div`position: relative;`;
 
@@ -34,6 +36,7 @@ const Opener = styled.div`
 const mapDispatchToProps = dispatch => ({
   sandboxActions: bindActionCreators(sandboxActionCreators, dispatch),
   openMenu: bindActionCreators(contextMenuActionCreators, dispatch).openMenu,
+  modalActions: bindActionCreators(modalActionCreators, dispatch)
 });
 type Props = {
   id: string,
@@ -49,11 +52,12 @@ type Props = {
   depth: ?number,
   openMenu: (e: Event) => void,
   sandboxActions: typeof sandboxActionCreators,
+  modalActions: typeof modalActionCreators,
   currentModuleId: ?string,
-  isInProjectView: boolean,
+  isInProjectView: boolean
 };
 type State = {
-  creating: '' | 'module' | 'directory',
+  creating: '' | 'module' | 'directory'
 };
 class DirectoryEntry extends React.PureComponent {
   props: Props;
@@ -73,7 +77,7 @@ class DirectoryEntry extends React.PureComponent {
 
     this.state = {
       creating: '',
-      open: props.root || isParentOfModule,
+      open: props.root || isParentOfModule
     };
   }
 
@@ -101,7 +105,7 @@ class DirectoryEntry extends React.PureComponent {
   onCreateModuleClick = () => {
     this.setState({
       creating: 'module',
-      open: true,
+      open: true
     });
     return true;
   };
@@ -118,23 +122,27 @@ class DirectoryEntry extends React.PureComponent {
   };
 
   deleteModule = (id: string) => {
-    const { sandboxId, modules, sandboxActions } = this.props;
+    const { sandboxId, modules, sandboxActions, modalActions } = this.props;
     const module = modules.find(m => m.id === id);
 
-    const confirmed = confirm(
-      `Are you sure you want to delete ${module.title}?`
-    );
-
-    if (confirmed) {
-      sandboxActions.deleteModule(sandboxId, id);
-    }
-    return true;
+    modalActions.openModal({
+      Body: (
+        <DeleteFile
+          filename={module.title}
+          onCancel={modalActions.closeModal}
+          onDelete={() => {
+            modalActions.closeModal();
+            sandboxActions.deleteModule(sandboxId, id);
+          }}
+        />
+      )
+    });
   };
 
   onCreateDirectoryClick = () => {
     this.setState({
       creating: 'directory',
-      open: true,
+      open: true
     });
     return true;
   };
@@ -184,7 +192,7 @@ class DirectoryEntry extends React.PureComponent {
 
     return [
       ...modules.filter(m => m.directoryShortid === shortid),
-      ...directories.filter(d => d.directoryShortid === shortid),
+      ...directories.filter(d => d.directoryShortid === shortid)
     ];
   };
 
@@ -207,7 +215,7 @@ class DirectoryEntry extends React.PureComponent {
       isOver, // eslint-disable-line
       isInProjectView,
       depth = 0,
-      root,
+      root
     } = this.props;
     const { creating, open } = this.state;
 
@@ -307,7 +315,7 @@ const entryTarget = {
 
     if (source.id === props.id) return false;
     return true;
-  },
+  }
 };
 
 function collectTarget(connectMonitor, monitor) {
@@ -318,7 +326,7 @@ function collectTarget(connectMonitor, monitor) {
     // You can ask the monitor about the current drag state:
     isOver: monitor.isOver({ shallow: true }),
     canDrop: monitor.canDrop(),
-    itemType: monitor.getItemType(),
+    itemType: monitor.getItemType()
   };
 }
 

--- a/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/index.js
+++ b/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/index.js
@@ -1,20 +1,20 @@
-import React from 'react';
-import styled from 'styled-components';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
-import { DropTarget } from 'react-dnd';
+import React from "react";
+import styled from "styled-components";
+import { connect } from "react-redux";
+import { bindActionCreators } from "redux";
+import { DropTarget } from "react-dnd";
 
-import type { Module, Directory } from 'common/types';
+import type { Module, Directory } from "common/types";
 
-import sandboxActionCreators from 'app/store/entities/sandboxes/actions';
-import { validateTitle } from 'app/store/entities//sandboxes/modules/validator';
-import contextMenuActionCreators from 'app/store/context-menu/actions';
-import { getModuleParents } from 'app/store/entities/sandboxes/modules/selectors';
-import modalActionCreators from 'app/store/modal/actions';
+import sandboxActionCreators from "app/store/entities/sandboxes/actions";
+import { validateTitle } from "app/store/entities//sandboxes/modules/validator";
+import contextMenuActionCreators from "app/store/context-menu/actions";
+import { getModuleParents } from "app/store/entities/sandboxes/modules/selectors";
+import modalActionCreators from "app/store/modal/actions";
 
-import Entry from './Entry';
-import DirectoryChildren from './DirectoryChildren';
-import DeleteFile from './DeleteFile';
+import Entry from "./Entry";
+import DirectoryChildren from "./DirectoryChildren";
+import DeleteFile from "./DeleteFile";
 
 const EntryContainer = styled.div`position: relative;`;
 
@@ -25,11 +25,11 @@ const Overlay = styled.div`
   left: 0;
   right: 0;
   background-color: rgba(0, 0, 0, 0.3);
-  display: ${props => (props.isOver ? 'block' : 'none')};
+  display: ${props => (props.isOver ? "block" : "none")};
 `;
 
 const Opener = styled.div`
-  height: ${props => (props.open ? '100%' : '0px')};
+  height: ${props => (props.open ? "100%" : "0px")};
   overflow: hidden;
 `;
 
@@ -57,7 +57,7 @@ type Props = {
   isInProjectView: boolean
 };
 type State = {
-  creating: '' | 'module' | 'directory'
+  creating: "" | "module" | "directory"
 };
 class DirectoryEntry extends React.PureComponent {
   props: Props;
@@ -76,7 +76,7 @@ class DirectoryEntry extends React.PureComponent {
     const isParentOfModule = currentModuleParents.includes(id);
 
     this.state = {
-      creating: '',
+      creating: "",
       open: props.root || isParentOfModule
     };
   }
@@ -100,11 +100,11 @@ class DirectoryEntry extends React.PureComponent {
     }
   }
 
-  resetState = () => this.setState({ creating: '' });
+  resetState = () => this.setState({ creating: "" });
 
   onCreateModuleClick = () => {
     this.setState({
-      creating: 'module',
+      creating: "module",
       open: true
     });
     return true;
@@ -128,7 +128,14 @@ class DirectoryEntry extends React.PureComponent {
     modalActions.openModal({
       Body: (
         <DeleteFile
-          filename={module.title}
+          title="Delete File"
+          body={
+            <span>
+              Are you sure you want to delete <b>{module.title}</b>?
+              <br />
+              The file will be permanently removed.
+            </span>
+          }
           onCancel={modalActions.closeModal}
           onDelete={() => {
             modalActions.closeModal();
@@ -141,7 +148,7 @@ class DirectoryEntry extends React.PureComponent {
 
   onCreateDirectoryClick = () => {
     this.setState({
-      creating: 'directory',
+      creating: "directory",
       open: true
     });
     return true;
@@ -220,7 +227,7 @@ class DirectoryEntry extends React.PureComponent {
     const { creating, open } = this.state;
 
     return connectDropTarget(
-      <div style={{ position: 'relative' }}>
+      <div style={{ position: "relative" }}>
         <Overlay isOver={isOver} />
         <EntryContainer>
           <Entry
@@ -242,7 +249,7 @@ class DirectoryEntry extends React.PureComponent {
           />
         </EntryContainer>
         <Opener open={open}>
-          {creating === 'directory' && (
+          {creating === "directory" &&
             <Entry
               id=""
               title=""
@@ -252,8 +259,7 @@ class DirectoryEntry extends React.PureComponent {
               renameValidator={this.validateModuleTitle}
               rename={this.createDirectory}
               onRenameCancel={this.resetState}
-            />
-          )}
+            />}
           <DirectoryChildren
             modules={modules}
             directories={directories}
@@ -267,7 +273,7 @@ class DirectoryEntry extends React.PureComponent {
             currentModuleId={currentModuleId}
             isInProjectView={isInProjectView}
           />
-          {creating === 'module' && (
+          {creating === "module" &&
             <Entry
               id=""
               title=""
@@ -276,8 +282,7 @@ class DirectoryEntry extends React.PureComponent {
               renameValidator={this.validateModuleTitle}
               rename={this.createModule}
               onRenameCancel={this.resetState}
-            />
-          )}
+            />}
         </Opener>
       </div>
     );
@@ -331,5 +336,5 @@ function collectTarget(connectMonitor, monitor) {
 }
 
 export default connect(null, mapDispatchToProps)(
-  DropTarget('ENTRY', entryTarget, collectTarget)(DirectoryEntry)
+  DropTarget("ENTRY", entryTarget, collectTarget)(DirectoryEntry)
 );

--- a/src/app/pages/Sandbox/Editor/Workspace/SandboxActions/index.js
+++ b/src/app/pages/Sandbox/Editor/Workspace/SandboxActions/index.js
@@ -1,20 +1,16 @@
-import React from 'react';
-import styled from 'styled-components';
+import React from "react";
+import { connect } from "react-redux";
+import { bindActionCreators } from "redux";
+import styled from "styled-components";
 
-import Button from 'app/components/buttons/Button';
+import Button from "app/components/buttons/Button";
 
-import WorkspaceInputContainer from '../WorkspaceInputContainer';
+import modalActionCreators from "app/store/modal/actions";
+import Alert from "app/components/Alert";
 
-import WorkspaceSubtitle from '../WorkspaceSubtitle';
+import WorkspaceInputContainer from "../WorkspaceInputContainer";
 
-type Props = {
-  id: string,
-  deleteSandbox: (id: string) => void,
-  newSandboxUrl: () => void,
-  setSandboxPrivacy: (id: string, privacy: number) => void,
-  isPatron: boolean,
-  privacy: 0 | 1 | 2,
-};
+import WorkspaceSubtitle from "../WorkspaceSubtitle";
 
 const PrivacySelect = styled.select`
   background-color: rgba(0, 0, 0, 0.3);
@@ -28,18 +24,43 @@ const PrivacySelect = styled.select`
   box-sizing: border-box;
 `;
 
-export default class SandboxSettings extends React.PureComponent {
+const mapDispatchToProps = dispatch => ({
+  modalActions: bindActionCreators(modalActionCreators, dispatch)
+});
+
+type Props = {
+  id: string,
+  deleteSandbox: (id: string) => void,
+  newSandboxUrl: () => void,
+  setSandboxPrivacy: (id: string, privacy: number) => void,
+  isPatron: boolean,
+  privacy: 0 | 1 | 2,
+  modalActions: typeof modalActionCreators
+};
+
+class SandboxSettings extends React.PureComponent {
   props: Props;
   state = {
-    loading: false,
+    loading: false
   };
 
-  handleDeleteSandbox = async () => {
-    const really = confirm('Are you sure you want to delete this sandbox?'); // TODO: confirm???
-    if (really) {
-      await this.props.deleteSandbox(this.props.id);
-      await this.props.newSandboxUrl();
-    }
+  handleDeleteSandbox = () => {
+    const { modalActions } = this.props;
+
+    modalActions.openModal({
+      Body: (
+        <Alert
+          title="Delete File"
+          body={<span>Are you sure you want to delete this sandbox?</span>}
+          onCancel={modalActions.closeModal}
+          onDelete={async () => {
+            await this.props.deleteSandbox(this.props.id);
+            await this.props.newSandboxUrl();
+            modalActions.closeModal();
+          }}
+        />
+      )
+    });
   };
 
   updateSandboxPrivacy = async e => {
@@ -62,7 +83,7 @@ export default class SandboxSettings extends React.PureComponent {
     const { isPatron, privacy } = this.props;
     return (
       <div>
-        {isPatron && (
+        {isPatron &&
           <div>
             <WorkspaceSubtitle>Sandbox Privacy</WorkspaceSubtitle>
             <WorkspaceInputContainer>
@@ -75,16 +96,15 @@ export default class SandboxSettings extends React.PureComponent {
                 <option value={2}>Private</option>
               </PrivacySelect>
             </WorkspaceInputContainer>
-          </div>
-        )}
+          </div>}
         <WorkspaceSubtitle>Delete Sandbox</WorkspaceSubtitle>
         <WorkspaceInputContainer>
           <Button
             small
             block
             style={{
-              margin: '0.5rem 0.25rem',
-              boxSizing: 'border-box',
+              margin: "0.5rem 0.25rem",
+              boxSizing: "border-box"
             }}
             onClick={this.handleDeleteSandbox}
           >
@@ -95,3 +115,5 @@ export default class SandboxSettings extends React.PureComponent {
     );
   }
 }
+
+export default connect(undefined, mapDispatchToProps)(SandboxSettings);

--- a/src/app/pages/Sandbox/Editor/Workspace/SandboxActions/index.js
+++ b/src/app/pages/Sandbox/Editor/Workspace/SandboxActions/index.js
@@ -53,9 +53,9 @@ class SandboxSettings extends React.PureComponent {
           title="Delete File"
           body={<span>Are you sure you want to delete this sandbox?</span>}
           onCancel={modalActions.closeModal}
-          onDelete={async () => {
-            await this.props.deleteSandbox(this.props.id);
-            await this.props.newSandboxUrl();
+          onDelete={() => {
+            this.props.deleteSandbox(this.props.id);
+            this.props.newSandboxUrl();
             modalActions.closeModal();
           }}
         />

--- a/src/app/pages/Sandbox/Editor/Workspace/SandboxActions/index.js
+++ b/src/app/pages/Sandbox/Editor/Workspace/SandboxActions/index.js
@@ -1,16 +1,16 @@
-import React from "react";
-import { connect } from "react-redux";
-import { bindActionCreators } from "redux";
-import styled from "styled-components";
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import styled from 'styled-components';
 
-import Button from "app/components/buttons/Button";
+import Button from 'app/components/buttons/Button';
 
-import modalActionCreators from "app/store/modal/actions";
-import Alert from "app/components/Alert";
+import modalActionCreators from 'app/store/modal/actions';
+import Alert from 'app/components/Alert';
 
-import WorkspaceInputContainer from "../WorkspaceInputContainer";
+import WorkspaceInputContainer from '../WorkspaceInputContainer';
 
-import WorkspaceSubtitle from "../WorkspaceSubtitle";
+import WorkspaceSubtitle from '../WorkspaceSubtitle';
 
 const PrivacySelect = styled.select`
   background-color: rgba(0, 0, 0, 0.3);
@@ -25,7 +25,7 @@ const PrivacySelect = styled.select`
 `;
 
 const mapDispatchToProps = dispatch => ({
-  modalActions: bindActionCreators(modalActionCreators, dispatch)
+  modalActions: bindActionCreators(modalActionCreators, dispatch),
 });
 
 type Props = {
@@ -35,13 +35,13 @@ type Props = {
   setSandboxPrivacy: (id: string, privacy: number) => void,
   isPatron: boolean,
   privacy: 0 | 1 | 2,
-  modalActions: typeof modalActionCreators
+  modalActions: typeof modalActionCreators,
 };
 
 class SandboxSettings extends React.PureComponent {
   props: Props;
   state = {
-    loading: false
+    loading: false,
   };
 
   handleDeleteSandbox = () => {
@@ -59,7 +59,7 @@ class SandboxSettings extends React.PureComponent {
             modalActions.closeModal();
           }}
         />
-      )
+      ),
     });
   };
 
@@ -83,7 +83,7 @@ class SandboxSettings extends React.PureComponent {
     const { isPatron, privacy } = this.props;
     return (
       <div>
-        {isPatron &&
+        {isPatron && (
           <div>
             <WorkspaceSubtitle>Sandbox Privacy</WorkspaceSubtitle>
             <WorkspaceInputContainer>
@@ -96,15 +96,16 @@ class SandboxSettings extends React.PureComponent {
                 <option value={2}>Private</option>
               </PrivacySelect>
             </WorkspaceInputContainer>
-          </div>}
+          </div>
+        )}
         <WorkspaceSubtitle>Delete Sandbox</WorkspaceSubtitle>
         <WorkspaceInputContainer>
           <Button
             small
             block
             style={{
-              margin: "0.5rem 0.25rem",
-              boxSizing: "border-box"
+              margin: '0.5rem 0.25rem',
+              boxSizing: 'border-box',
             }}
             onClick={this.handleDeleteSandbox}
           >


### PR DESCRIPTION
This PR adds a modal for confirming file deletion, instead of using `alert()`. If you're happy with it, we can also do something similar for deleting sandboxes.

I'm not particularly happy with the design. It's not something I'm very good at. I tried using elements that exist on other places already. Actually, the red colour for the Delete button doesn't feel right...

I'm not sure if you want this. Maybe you want to keep `alert()` but I assumed it was done this way initially because it was the easiest approach. 😄 

![deletemodal](https://user-images.githubusercontent.com/9586897/29753826-4d2a97d6-8b82-11e7-96a8-16ac1666cb5c.gif)

As usual, I learned quite a lot by looking at your Modal implementation (1 instance of `Modal` and keeping everything else in the state), and I'll probably use the same approach for another project where we recently started adding more modals. 

**PS:** I noticed my diff includes a lot of trailing comma removals. This was done by the pre-commit hook, is it expected?