### PR TITLE
Fix plugin order to re-enable using decorators

### DIFF
--- a/src/sandbox/eval/transpilers/babel/babel-parser.js
+++ b/src/sandbox/eval/transpilers/babel/babel-parser.js
@@ -8,8 +8,8 @@ const DEFAULT_BABEL_CONFIG = {
   plugins: [
     'transform-async-to-generator',
     'transform-object-rest-spread',
-    'transform-class-properties',
     'transform-decorators-legacy',
+    'transform-class-properties',
   ],
 };
 


### PR DESCRIPTION
For example https://codesandbox.io/s/2vmzpM0wK is now broken. See also: https://github.com/mobxjs/mobx/issues/1154

Fixes https://github.com/CompuIves/codesandbox-client/issues/151