### PR TITLE
Rewrite /embed to /embed.html. Fixes #158.

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -177,6 +177,7 @@ function addMiddleware(devServer, index) {
       // If this heuristic doesn’t work well for you, don’t use `proxy`.
       htmlAcceptHeaders: ['text/html'],
       index,
+      rewrites: [{ from: /\/embed/, to: '/embed.html' }],
     })
   );
   if (process.env.LOCAL_SERVER) {


### PR DESCRIPTION
Fixes https://github.com/CompuIves/codesandbox-client/issues/158.