### PR TITLE
ShareView: make inputs and textareas explicit readonly.

### DIFF
--- a/src/app/pages/Sandbox/Editor/Content/Header/ShareView.js
+++ b/src/app/pages/Sandbox/Editor/Content/Header/ShareView.js
@@ -388,15 +388,28 @@ class ShareView extends React.PureComponent {
                   <ButtonName>Links</ButtonName>
                   <Inputs>
                     <LinkName>Editor url</LinkName>
-                    <input onFocus={this.select} value={this.getEditorUrl()} />
+                    <input
+                      onFocus={this.select}
+                      value={this.getEditorUrl()}
+                      readOnly
+                    />
                     <LinkName>Fullscreen url</LinkName>
-                    <input onFocus={this.select} value={this.getEmbedUrl()} />
+                    <input
+                      onFocus={this.select}
+                      value={this.getEmbedUrl()}
+                      readOnly
+                    />
                     <LinkName>Embed url (Medium/Embedly)</LinkName>
-                    <input onFocus={this.select} value={this.getEditorUrl()} />
+                    <input
+                      onFocus={this.select}
+                      value={this.getEditorUrl()}
+                      readOnly
+                    />
                     <LinkName>iframe</LinkName>
                     <textarea
                       onFocus={this.select}
                       value={this.getIframeScript()}
+                      readOnly
                     />
                   </Inputs>
                 </Column>
@@ -415,12 +428,14 @@ class ShareView extends React.PureComponent {
                     <textarea
                       onFocus={this.select}
                       value={this.getButtonMarkdown()}
+                      readOnly
                     />
 
                     <LinkName>HTML</LinkName>
                     <textarea
                       onFocus={this.select}
                       value={this.getButtonHTML()}
+                      readOnly
                     />
                   </Inputs>
                 </Column>


### PR DESCRIPTION
Fixes https://github.com/CompuIves/codesandbox-client/issues/162.