### PR TITLE
Preserve resource order

### DIFF
--- a/src/app/pages/Sandbox/Editor/Workspace/Dependencies/index.js
+++ b/src/app/pages/Sandbox/Editor/Workspace/Dependencies/index.js
@@ -141,7 +141,6 @@ export default class Dependencies extends React.PureComponent<Props, State> {
         <div>
           <WorkspaceSubtitle>External Resources</WorkspaceSubtitle>
           {(externalResources || [])
-            .sort()
             .map(resource => (
               <ExternalResource
                 key={resource}

--- a/src/sandbox/external-resources.js
+++ b/src/sandbox/external-resources.js
@@ -1,4 +1,4 @@
-function getExternalResourcesConcatination(resources: Array<string>) {
+function getExternalResourcesConcatenation(resources: Array<string>) {
   return resources.sort().join('');
 }
 
@@ -44,8 +44,8 @@ function addResource(resource: string) {
 
 let cachedExternalResources = '';
 
-export default function handelExternalResources(externalResources) {
-  const extResString = getExternalResourcesConcatination(externalResources);
+export default function handleExternalResources(externalResources) {
+  const extResString = getExternalResourcesConcatenation(externalResources);
   if (extResString !== cachedExternalResources) {
     clearExternalResources();
     externalResources.forEach(addResource);

--- a/src/sandbox/external-resources.js
+++ b/src/sandbox/external-resources.js
@@ -1,5 +1,5 @@
 function getExternalResourcesConcatenation(resources: Array<string>) {
-  return resources.sort().join('');
+  return resources.join('');
 }
 
 function clearExternalResources() {

--- a/src/sandbox/external-resources.js
+++ b/src/sandbox/external-resources.js
@@ -27,7 +27,7 @@ function addCSS(resource: string) {
 function addJS(resource: string) {
   const script = document.createElement('script');
   script.setAttribute('src', resource);
-  script.setAttribute('async', false);
+  script.async = false;
   script.setAttribute('id', 'external-js');
   document.head.appendChild(script);
 }


### PR DESCRIPTION
The order in which resources (especially `<script>`s) are loaded is important in cases where there are dependencies between them (most notable case is jQuery). That's the reason for which sorting the resources by name in the Dependencies > External Resources section in the left pane can be misleading.
Also the reason for which I removed `sort()` from `getExternalResourcesConcatenation()` (`['a.js', 'b.js']` should not be equivalent to `['b.js', 'a.js']`).

There was another issue with the way `async` was set on resources `<script>`s, as a HTML attribute instead of a DOM element attribute (see https://developer.mozilla.org/en/docs/Web/API/HTMLScriptElement#async_property).

After these changes, adding jQuery and a plugin that depends on it works, regardless of the time they load in (I was having issues with [MaterializeCSS](http://materializecss.com/) loading faster than jQuery, executing first and failing not finding jQuery).