### PR TITLE
Fix issue when clicking prettify when the sandbox contains syntax errors

### DIFF
--- a/src/app/components/sandbox/CodeEditor/CodeMirror.js
+++ b/src/app/components/sandbox/CodeEditor/CodeMirror.js
@@ -426,7 +426,6 @@ export default class CodeEditor extends React.PureComponent<Props, State> {
   getCode = () => this.codemirror.getValue();
 
   prettify = async () => {
-    console.log('Prettify!!');
     const { id, title, preferences } = this.props;
     const code = this.getCode();
     const mode = await this.getMode(title);

--- a/src/app/components/sandbox/CodeEditor/CodeMirror.js
+++ b/src/app/components/sandbox/CodeEditor/CodeMirror.js
@@ -168,12 +168,9 @@ const handleError = (
   nextId: string
 ) => {
   if (currentErrors && currentErrors.length > 0) {
-    cm
-      .getValue()
-      .split('\n')
-      .forEach((_, i) => {
-        cm.removeLineClass(i, 'background', 'cm-line-error');
-      });
+    cm.getValue().split('\n').forEach((_, i) => {
+      cm.removeLineClass(i, 'background', 'cm-line-error');
+    });
   }
 
   if (nextErrors) {
@@ -429,6 +426,7 @@ export default class CodeEditor extends React.PureComponent<Props, State> {
   getCode = () => this.codemirror.getValue();
 
   prettify = async () => {
+    console.log('Prettify!!');
     const { id, title, preferences } = this.props;
     const code = this.getCode();
     const mode = await this.getMode(title);
@@ -442,7 +440,7 @@ export default class CodeEditor extends React.PureComponent<Props, State> {
           preferences.prettierConfig
         );
 
-        if (newCode !== code) {
+        if (newCode && newCode !== code) {
           this.props.changeCode(id, newCode);
           this.updateCodeMirrorCode(newCode);
         }
@@ -511,15 +509,14 @@ export default class CodeEditor extends React.PureComponent<Props, State> {
           fontFamily={preferences.fontFamily}
           lineHeight={preferences.lineHeight}
         >
-          {this.state.fuzzySearchEnabled && (
+          {this.state.fuzzySearchEnabled &&
             <FuzzySearch
               closeFuzzySearch={this.closeFuzzySearch}
               setCurrentModule={this.setCurrentModule}
               modules={modules}
               directories={directories}
               currentModuleId={id}
-            />
-          )}
+            />}
           <div
             style={{ height: '100%', fontSize: preferences.fontSize || 14 }}
             ref={this.getCodeMirror}

--- a/src/app/components/sandbox/CodeEditor/CodeMirror.js
+++ b/src/app/components/sandbox/CodeEditor/CodeMirror.js
@@ -168,9 +168,12 @@ const handleError = (
   nextId: string
 ) => {
   if (currentErrors && currentErrors.length > 0) {
-    cm.getValue().split('\n').forEach((_, i) => {
-      cm.removeLineClass(i, 'background', 'cm-line-error');
-    });
+    cm
+      .getValue()
+      .split('\n')
+      .forEach((_, i) => {
+        cm.removeLineClass(i, 'background', 'cm-line-error');
+      });
   }
 
   if (nextErrors) {
@@ -508,14 +511,15 @@ export default class CodeEditor extends React.PureComponent<Props, State> {
           fontFamily={preferences.fontFamily}
           lineHeight={preferences.lineHeight}
         >
-          {this.state.fuzzySearchEnabled &&
+          {this.state.fuzzySearchEnabled && (
             <FuzzySearch
               closeFuzzySearch={this.closeFuzzySearch}
               setCurrentModule={this.setCurrentModule}
               modules={modules}
               directories={directories}
               currentModuleId={id}
-            />}
+            />
+          )}
           <div
             style={{ height: '100%', fontSize: preferences.fontSize || 14 }}
             ref={this.getCodeMirror}

--- a/src/app/components/sandbox/CodeEditor/Monaco.js
+++ b/src/app/components/sandbox/CodeEditor/Monaco.js
@@ -722,6 +722,7 @@ export default class CodeEditor extends React.PureComponent<Props, State> {
   getCode = () => this.editor.getValue();
 
   prettify = async () => {
+    console.log('Prettify Monaco!!');
     const { id, title, preferences } = this.props;
     const code = this.getCode();
     const mode = this.getMode(title);
@@ -736,7 +737,7 @@ export default class CodeEditor extends React.PureComponent<Props, State> {
           preferences.prettierConfig
         );
 
-        if (newCode !== code) {
+        if (newCode && newCode !== code) {
           this.props.changeCode(id, newCode);
           this.updateCode(newCode);
         }
@@ -802,15 +803,14 @@ export default class CodeEditor extends React.PureComponent<Props, State> {
           path={modulePath}
         />
         <CodeContainer>
-          {this.state.fuzzySearchEnabled && (
+          {this.state.fuzzySearchEnabled &&
             <FuzzySearch
               closeFuzzySearch={this.closeFuzzySearch}
               setCurrentModule={this.setCurrentModule}
               modules={modules}
               directories={directories}
               currentModuleId={this.props.id}
-            />
-          )}
+            />}
           <MonacoEditor
             width="100%"
             height="100%"

--- a/src/app/components/sandbox/CodeEditor/Monaco.js
+++ b/src/app/components/sandbox/CodeEditor/Monaco.js
@@ -722,7 +722,6 @@ export default class CodeEditor extends React.PureComponent<Props, State> {
   getCode = () => this.editor.getValue();
 
   prettify = async () => {
-    console.log('Prettify Monaco!!');
     const { id, title, preferences } = this.props;
     const code = this.getCode();
     const mode = this.getMode(title);

--- a/src/app/components/sandbox/CodeEditor/Monaco.js
+++ b/src/app/components/sandbox/CodeEditor/Monaco.js
@@ -802,14 +802,15 @@ export default class CodeEditor extends React.PureComponent<Props, State> {
           path={modulePath}
         />
         <CodeContainer>
-          {this.state.fuzzySearchEnabled &&
+          {this.state.fuzzySearchEnabled && (
             <FuzzySearch
               closeFuzzySearch={this.closeFuzzySearch}
               setCurrentModule={this.setCurrentModule}
               modules={modules}
               directories={directories}
               currentModuleId={this.props.id}
-            />}
+            />
+          )}
           <MonacoEditor
             width="100%"
             height="100%"


### PR DESCRIPTION
Check that newCode is actually defined before switching the output. I hope the issue description and fix speak for itself. 😄 

https://github.com/CompuIves/codesandbox-client/issues/185

**Edit:** I don't understand why my commits contain stylistic changes to other parts of the code in the same file. I suppose it's some issue from my side with Prettier?