### PR TITLE
Sandbox preview: make navigator's back button inactive on first load

### DIFF
--- a/src/app/components/sandbox/Preview/index.js
+++ b/src/app/components/sandbox/Preview/index.js
@@ -351,7 +351,7 @@ export default class Preview extends React.PureComponent<Props, State> {
             url={decodeURIComponent(url)}
             onChange={this.updateUrl}
             onConfirm={this.sendUrl}
-            onBack={historyPosition > 0 && this.handleBack}
+            onBack={historyPosition > 1 && this.handleBack}
             onForward={
               historyPosition < history.length - 1 && this.handleForward
             }


### PR DESCRIPTION
`historyPosition` starts at 1 (because of the initial `sendUrlChange()` -> `commitUrl()` with the sandbox URL), so the condition `historyPosition > 0` is always true.

Fixes https://github.com/CompuIves/codesandbox-client/issues/195.