### PR TITLE
Sandbox preview: replace window.history with our own emulated history

### DIFF
--- a/src/app/components/sandbox/Preview/index.js
+++ b/src/app/components/sandbox/Preview/index.js
@@ -65,7 +65,7 @@ export default class Preview extends React.PureComponent<Props, State> {
     this.state = {
       frameInitialized: false,
       history: [],
-      historyPosition: 0,
+      historyPosition: -1,
       urlInAddressBar: frameUrl(props.sandboxId, props.initialPath || ''),
       url: null,
     };
@@ -347,7 +347,7 @@ export default class Preview extends React.PureComponent<Props, State> {
             url={decodeURIComponent(url)}
             onChange={this.updateUrl}
             onConfirm={this.sendUrl}
-            onBack={historyPosition > 1 ? this.handleBack : null}
+            onBack={historyPosition > 0 ? this.handleBack : null}
             onForward={
               historyPosition < history.length - 1 ? this.handleForward : null
             }

--- a/src/app/components/sandbox/Preview/index.js
+++ b/src/app/components/sandbox/Preview/index.js
@@ -86,16 +86,24 @@ export default class Preview extends React.PureComponent<Props, State> {
     noDelay: false,
   };
 
+  componentWillReceiveProps(nextProps: Props) {
+    if (nextProps.sandboxId !== this.props.sandboxId) {
+      const url = frameUrl(nextProps.sandboxId, this.initialPath);
+      this.setState({
+        history: [url],
+        historyPosition: 0,
+        urlInAddressBar: url,
+      });
+    }
+  }
+
   componentDidUpdate(prevProps: Props) {
     if (prevProps.isInProjectView !== this.props.isInProjectView) {
       this.executeCodeImmediately();
       return;
     }
 
-    if (prevProps.sandboxId !== this.props.sandboxId) {
-      this.executeCodeImmediately();
-      return;
-    } else if (prevProps.forcedRenders !== this.props.forcedRenders) {
+    if (prevProps.forcedRenders !== this.props.forcedRenders) {
       this.executeCodeImmediately();
       return;
     }

--- a/src/app/components/sandbox/Preview/index.js
+++ b/src/app/components/sandbox/Preview/index.js
@@ -269,16 +269,23 @@ export default class Preview extends React.PureComponent<Props, State> {
 
     document.getElementById('sandbox').src = urlInAddressBar;
 
-    this.commitUrl(urlInAddressBar);
+    this.setState({
+      history: [urlInAddressBar],
+      historyPosition: 0,
+      urlInAddressBar,
+    });
   };
 
   handleRefresh = () => {
     const { history, historyPosition } = this.state;
+    const url = history[historyPosition];
 
-    document.getElementById('sandbox').src = history[historyPosition];
+    document.getElementById('sandbox').src = url;
 
     this.setState({
-      urlInAddressBar: history[historyPosition],
+      history: [url],
+      historyPosition: 0,
+      urlInAddressBar: url,
     });
   };
 

--- a/src/sandbox/url-listeners.js
+++ b/src/sandbox/url-listeners.js
@@ -60,14 +60,12 @@ export default function setupHistoryListeners() {
       },
 
       pushState(state, title, url) {
-        console.log(`pushState("${state}", "${title}", "${url}")`);
         origHistoryProto.replaceState.call(window.history, state, title, url);
         pushHistory(url, state);
         sendUrlChange(document.location.href);
       },
 
       replaceState(state, title, url) {
-        console.log(`replaceState("${state}", "${title}", "${url}")`);
         origHistoryProto.replaceState.call(window.history, state, title, url);
         historyList[historyPosition] = { state, url };
         sendUrlChange(document.location.href);
@@ -77,22 +75,13 @@ export default function setupHistoryListeners() {
     Object.defineProperties(window.history, {
       length: {
         get() {
-          console.log('get length()');
           return historyList.length;
         },
       },
 
       state: {
         get() {
-          console.log('get state()');
           return historyList[historyPosition].state;
-        },
-      },
-
-      // debug only
-      historyList: {
-        get() {
-          return { position: historyPosition, list: historyList };
         },
       },
     });
@@ -123,8 +112,6 @@ export default function setupHistoryListeners() {
             );
             pushHistory(pathWithHash(document.location), null);
             sendUrlChange(document.location.href);
-          } else {
-            console.log('same url');
           }
           ev.preventDefault();
           ev.stopPropagation();

--- a/src/sandbox/url-listeners.js
+++ b/src/sandbox/url-listeners.js
@@ -1,4 +1,4 @@
-import { dispatch } from 'codesandbox-api';
+import { dispatch, isStandalone } from 'codesandbox-api';
 
 function sendUrlChange(url: string) {
   dispatch({
@@ -7,40 +7,129 @@ function sendUrlChange(url: string) {
   });
 }
 
+/* eslint-disable no-console */
+
+const origHistoryProto = window.history.__proto__; // eslint-disable-line no-proto
+const historyList = [];
+let historyPosition = -1;
+let disableNextHashChange = false;
+
+function pushHistory(url, state) {
+  if (historyPosition === -1 || historyList[historyPosition].url !== url) {
+    historyPosition += 1;
+    historyList.length = historyPosition + 1;
+    historyList[historyPosition] = { url, state };
+  }
+}
+
+function pathWithHash(location) {
+  return `${location.pathname}${location.hash}`;
+}
+
 export default function setupHistoryListeners() {
-  const pushState = window.history.pushState;
-  window.history.pushState = function(state) {
-    if (typeof history.onpushstate === 'function') {
-      window.history.onpushstate({ state });
-    }
-    // ... whatever else you want to do
-    // maybe call onhashchange e.handler
-    return pushState.apply(window.history, arguments);
-  };
+  if (!isStandalone) {
+    const historyProto = {
+      get length() {
+        console.log('get length()');
+        return historyList.length;
+      },
 
-  const replaceState = window.history.replaceState;
-  window.history.replaceState = function(state) {
-    if (typeof history.onpushstate === 'function') {
-      window.history.onpushstate({ state });
-    }
-    // ... whatever else you want to do
-    // maybe call onhashchange e.handler
-    return replaceState.apply(window.history, arguments);
-  };
+      get state() {
+        console.log('get state()');
+        return historyList[historyPosition].state;
+      },
 
-  history.onpushstate = e => {
+      get historyList() {
+        return { position: historyPosition, list: historyList };
+      },
+
+      go(delta) {
+        console.log(`go(${delta})`);
+        const newPos = historyPosition + delta;
+        if (newPos >= 0 && newPos <= historyList.length - 1) {
+          historyPosition = newPos;
+          const { url, state } = historyList[historyPosition];
+          const oldURL = document.location.href;
+          origHistoryProto.replaceState.call(window.history, state, '', url);
+          const newURL = document.location.href;
+          if (newURL.indexOf('#') === -1) {
+            window.dispatchEvent(new PopStateEvent('popstate', { state }));
+          } else {
+            disableNextHashChange = true;
+            window.dispatchEvent(
+              new HashChangeEvent('hashchange', { oldURL, newURL })
+            );
+          }
+        }
+      },
+
+      back() {
+        console.log('back()');
+        window.history.go(-1);
+      },
+
+      forward() {
+        console.log('forward()');
+        window.history.go(1);
+      },
+
+      pushState(state, title, url) {
+        console.log(`pushState("${state}", "${title}", "${url}")`);
+        origHistoryProto.replaceState.call(window.history, state, title, url);
+        pushHistory(url, state);
+        sendUrlChange(document.location.href);
+      },
+
+      replaceState(state, title, url) {
+        console.log(`replaceState("${state}", "${title}", "${url}")`);
+        origHistoryProto.replaceState.call(window.history, state, title, url);
+        historyList[historyPosition] = { state, url };
+        sendUrlChange(document.location.href);
+      },
+    };
+
+    window.addEventListener('hashchange', () => {
+      if (!disableNextHashChange) {
+        const url = `${document.location.pathname}${document.location.hash}`;
+        pushHistory(url, null);
+        sendUrlChange(document.location.href);
+      } else {
+        disableNextHashChange = false;
+      }
+    });
+
+    document.addEventListener(
+      'click',
+      ev => {
+        const el = ev.target;
+        if (el.nodeName === 'A' && el.href.indexOf('#') !== -1) {
+          const url = el.href;
+          const oldURL = document.location.href;
+          origHistoryProto.replaceState.call(window.history, null, '', url);
+          const newURL = document.location.href;
+          if (oldURL !== newURL) {
+            disableNextHashChange = true;
+            window.dispatchEvent(
+              new HashChangeEvent('hashchange', { oldURL, newURL })
+            );
+            pushHistory(pathWithHash(document.location), null);
+            sendUrlChange(document.location.href);
+          } else {
+            console.log('same url');
+          }
+          ev.preventDefault();
+          ev.stopPropagation();
+        }
+      },
+      true
+    );
+
+    pushHistory(pathWithHash(document.location), null);
+
     setTimeout(() => {
       sendUrlChange(document.location.href);
     });
-  };
 
-  history.onreplacestate = e => {
-    setTimeout(() => {
-      sendUrlChange(document.location.href);
-    });
-  };
-
-  setTimeout(() => {
-    sendUrlChange(document.location.href);
-  });
+    window.history.__proto__ = historyProto; // eslint-disable-line no-proto
+  }
 }

--- a/src/sandbox/url-listeners.js
+++ b/src/sandbox/url-listeners.js
@@ -28,7 +28,7 @@ function pathWithHash(location) {
 
 export default function setupHistoryListeners() {
   if (!isStandalone) {
-    const newHistory = {
+    Object.assign(window.history, {
       go(delta) {
         console.log(`go(${delta})`);
         const newPos = historyPosition + delta;
@@ -72,32 +72,29 @@ export default function setupHistoryListeners() {
         historyList[historyPosition] = { state, url };
         sendUrlChange(document.location.href);
       },
-    };
-
-    Object.keys(newHistory).forEach(method => {
-      window.history[method] = newHistory[method];
     });
 
-    const newHistoryGetters = {
-      length() {
-        console.log('get length()');
-        return historyList.length;
+    Object.defineProperties(window.history, {
+      length: {
+        get() {
+          console.log('get length()');
+          return historyList.length;
+        },
       },
 
-      state() {
-        console.log('get state()');
-        return historyList[historyPosition].state;
+      state: {
+        get() {
+          console.log('get state()');
+          return historyList[historyPosition].state;
+        },
       },
 
-      historyList() {
-        return { position: historyPosition, list: historyList };
+      // debug only
+      historyList: {
+        get() {
+          return { position: historyPosition, list: historyList };
+        },
       },
-    };
-
-    Object.keys(newHistoryGetters).forEach(name => {
-      Object.defineProperty(window.history, name, {
-        get: newHistoryGetters[name],
-      });
     });
 
     window.addEventListener('hashchange', () => {


### PR DESCRIPTION
…, when inside the editor.

To do:
- [x] explain the approach
- [x] remove `console.log()`s, maybe some refactoring
- [x] (a lot) more testing
- ~~debug Firefox issue where `window.history.__proto__` is reset when bluring and focusing the window (tab?) again~~

I tested in latest versions of Chrome and Firefox, with both a React app and a Vue app using their corresponding routing libraries, in both `history` and `hash` mode.

Fixes https://github.com/CompuIves/codesandbox-client/issues/115 (and probably other issues related to history navigation behavior).