### PR TITLE
Show modal instead of alert

### DIFF
--- a/src/app/pages/Profile/Sandboxes/index.js
+++ b/src/app/pages/Profile/Sandboxes/index.js
@@ -39,6 +39,7 @@ type Props = {
   fetchSandboxes: Function,
   sandboxes: PaginatedSandboxes,
   sandboxActions: typeof sandboxActionCreators,
+  modalActions: typeof modalActionCreators,
   isCurrentUser: boolean,
 };
 
@@ -69,7 +70,7 @@ class Sandboxes extends React.PureComponent<Props> {
     return Math.ceil(sandboxCount / PER_PAGE_COUNT);
   };
 
-  deleteSandbox = async (id: string) => {
+  deleteSandbox = (id: string) => {
     const { modalActions } = this.props;
 
     modalActions.openModal({
@@ -81,6 +82,7 @@ class Sandboxes extends React.PureComponent<Props> {
           onDelete={async () => {
             await this.props.sandboxActions.deleteSandbox(id);
             this.fetch(true);
+            modalActions.closeModal();
           }}
         />
       ),

--- a/src/app/pages/Profile/Sandboxes/index.js
+++ b/src/app/pages/Profile/Sandboxes/index.js
@@ -7,6 +7,9 @@ import { connect } from 'react-redux';
 import Button from 'app/components/buttons/Button';
 import type { PaginatedSandboxes } from 'common/types';
 
+import modalActionCreators from 'app/store/modal/actions';
+import Alert from 'app/components/Alert';
+
 import SandboxList from 'app/components/sandbox/SandboxList';
 import sandboxActionCreators from 'app/store/entities/sandboxes/actions';
 
@@ -67,12 +70,21 @@ class Sandboxes extends React.PureComponent<Props> {
   };
 
   deleteSandbox = async (id: string) => {
-    // eslint-disable-next-line no-alert
-    const really = confirm(`Are you sure you want to delete this sandbox?`); // TODO: confirm???
-    if (really) {
-      await this.props.sandboxActions.deleteSandbox(id);
-      this.fetch(true);
-    }
+    const { modalActions } = this.props;
+
+    modalActions.openModal({
+      Body: (
+        <Alert
+          title="Delete File"
+          body={<span>Are you sure you want to delete this sandbox?</span>}
+          onCancel={modalActions.closeModal}
+          onDelete={async () => {
+            await this.props.sandboxActions.deleteSandbox(id);
+            this.fetch(true);
+          }}
+        />
+      ),
+    });
   };
 
   render() {
@@ -118,10 +130,9 @@ class Sandboxes extends React.PureComponent<Props> {
   }
 }
 
-const mapStateToProps = () => ({});
-
 const mapDispatchToProps = dispatch => ({
   sandboxActions: bindActionCreators(sandboxActionCreators, dispatch),
+  modalActions: bindActionCreators(modalActionCreators, dispatch),
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(Sandboxes);
+export default connect(undefined, mapDispatchToProps)(Sandboxes);

--- a/src/app/pages/Profile/Sandboxes/index.js
+++ b/src/app/pages/Profile/Sandboxes/index.js
@@ -75,7 +75,7 @@ class Sandboxes extends React.PureComponent<Props> {
     modalActions.openModal({
       Body: (
         <Alert
-          title="Delete File"
+          title="Delete Sandbox"
           body={<span>Are you sure you want to delete this sandbox?</span>}
           onCancel={modalActions.closeModal}
           onDelete={async () => {

--- a/src/app/pages/Sandbox/Editor/Workspace/SandboxActions/index.js
+++ b/src/app/pages/Sandbox/Editor/Workspace/SandboxActions/index.js
@@ -50,7 +50,7 @@ class SandboxSettings extends React.PureComponent {
     modalActions.openModal({
       Body: (
         <Alert
-          title="Delete File"
+          title="Delete Sandbox"
           body={<span>Are you sure you want to delete this sandbox?</span>}
           onCancel={modalActions.closeModal}
           onDelete={() => {


### PR DESCRIPTION
Add a modal (the same that is used in the editor when deleting a sandbox) when deleting sandbox from profile page, instead of alert.

Locally could only test it by forcing `isCurrentUser` to `true` in the code. But otherwise I could not manage to log in to Github when running locally. Though it seems to be working, but please do double-check 😄 