### PR TITLE
[WIP] add preprocessor UI

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/CSS/index.js
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/CSS/index.js
@@ -1,0 +1,110 @@
+// @flow
+import * as React from 'react';
+
+import WorkspaceInputContainer from '../WorkspaceInputContainer';
+import WorkspaceSubtitle from '../WorkspaceSubtitle';
+import PreferenceDropdown from '../../../../../components/Preference/PreferenceDropdown';
+import { TextArea } from '../../../../../components/Input';
+
+// I'll move this if needed, just not sure the best place for it.
+const PREPROCESSOR_TYPES = {
+  css: {
+    label: 'none',
+    options: false,
+  },
+  postcss: {
+    label: 'PostCSS',
+    options: true,
+    placeholder: `{ "use": [ require('postcss-cssnext') ] }`,
+  },
+  sass: {
+    label: 'Sass',
+    options: true,
+    placeholder: `{ precision: 3 }`,
+  },
+  acss: {
+    label: 'Atomic CSS',
+    options: true,
+    placeholder: `{ namespace: "#atomic" }`,
+  },
+  less: {
+    label: 'Less',
+    options: false,
+  },
+};
+
+type Props = {
+  // id: string,
+  preprocessor: string,
+  options?: string,
+  // preventTransition: boolean,
+};
+
+export default class CSS extends React.PureComponent<Props> {
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      preprocessor: props.preprocessor || 'css',
+      options: props.options,
+    };
+  }
+
+  setValue = (field: string) => (value: string) => {
+    // $FlowIssue
+    this.setState({ [field]: value });
+  };
+
+  componentWillReceiveProps = (nextProps: Props) => {
+    if (nextProps.preprocessor !== this.props.preprocessor) {
+      this.setState({ preprocessor: nextProps.preprocessor });
+    }
+    if (nextProps.options !== this.props.options) {
+      this.setState({ options: nextProps.options });
+    }
+  };
+
+  getPreprocessor = current =>
+    Object.entries(PREPROCESSOR_TYPES).filter(
+      ([preprocessor, { label }]) => preprocessor === current && label
+    )[(0)[0]];
+
+  getPreprocessorLabel = label =>
+    Object.keys(PREPROCESSOR_TYPES).reduce(
+      (acc, type) => (PREPROCESSOR_TYPES[type].label === label ? type : acc),
+      undefined
+    );
+
+  render() {
+    return (
+      <div>
+        <WorkspaceSubtitle>Preprocessor</WorkspaceSubtitle>
+        <WorkspaceInputContainer>
+          <PreferenceDropdown
+            value={this.getPreprocessor(this.state.preprocessor)}
+            setValue={value =>
+              this.setValue('preprocessor')(this.getPreprocessorLabel(value))
+            }
+            options={Object.entries(PREPROCESSOR_TYPES).map(
+              ([, { label }]) => label
+            )}
+          />
+        </WorkspaceInputContainer>
+
+        {PREPROCESSOR_TYPES[this.state.preprocessor].options && [
+          <WorkspaceSubtitle key="options-label">Options</WorkspaceSubtitle>,
+          <WorkspaceInputContainer key="options-input">
+            <TextArea
+              rows="10"
+              value={this.state.options}
+              onChange={evt => this.setValue('options')(evt.target.value)}
+              placeholder={
+                PREPROCESSOR_TYPES[this.state.preprocessor].placeholder
+              }
+            />
+          </WorkspaceInputContainer>,
+        ]}
+      </div>
+    );
+  }
+}

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/index.js
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/index.js
@@ -30,6 +30,7 @@ import WorkspaceInputContainer from './WorkspaceInputContainer';
 import Files from './Files';
 import Dependencies from './Dependencies';
 import Project from './Project';
+import CSS from './CSS';
 import Tags from './Tags';
 import WorkspaceItem from './WorkspaceItem';
 import SandboxActions from './SandboxActions';
@@ -136,6 +137,10 @@ class Workspace extends React.PureComponent<Props> {
                 privacy={sandbox.privacy}
                 template={sandbox.template}
               />
+            </WorkspaceItem>
+
+            <WorkspaceItem keepState title="CSS">
+              <CSS />
             </WorkspaceItem>
 
             <WorkspaceItem defaultOpen keepState title="Files">


### PR DESCRIPTION
as promised in #324 here's the start of the UI for a theoretical CSS Preprocessor option. I'd be happy to receive any feedback and iterate until we find something great.

This PR adds a sandbox workspace panel for CSS preprocessors. Each option goes in
an object with its value as the key, plus these properties:

```
{
  label: 'PostCSS',
  placeholder: 'this will show as the placeholder text for this option\'s
  textarea',
  options: true // this enables the options textarea
}
```

**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->
