### PR TITLE
fix: make react cube clickable by reducing radius size

### DIFF
--- a/packages/homepage/src/screens/home/Animation/Cubes.js
+++ b/packages/homepage/src/screens/home/Animation/Cubes.js
@@ -8,7 +8,7 @@ import Cube from '../../../components/Cube';
 import media from '../../../utils/media';
 import getScrollPos from '../../../utils/scroll';
 
-const RADIUS = 300;
+const RADIUS = 250;
 const Container = styled.div`
   flex: 2;
   position: relative;


### PR DESCRIPTION
Hello

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
Fix

<!-- You can also link to an open issue here -->
https://github.com/CompuIves/codesandbox-client/issues/301


<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A

<!-- feel free to add additional comments -->
The welcome screen is quite heavy on CPU. When I open it, lights on my street fade. Until I get some idea how to replace those 3d rotations with no hardware support, I'll just keep checking is there any car traffic before entering that page.

<!-- Thank you for contributing! -->
