### PR TITLE
Fix overflowing MaxWidth__Container

### DIFF
--- a/packages/common/components/flex/MaxWidth.js
+++ b/packages/common/components/flex/MaxWidth.js
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 const Container = styled.div`
+  box-sizing: border-box;
   display: flex;
 
   padding: 0 2rem;


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
Bug fix

<!-- You can also link to an open issue here -->
**What is the current behavior?**
MaxWidth__Container exceeds 100% width because of the additional paddings in content-box box-sizing

![image](https://user-images.githubusercontent.com/410792/33922539-6b79aa28-e006-11e7-8faf-6d79e94716b3.png)

<!-- if this is a feature change -->
**What is the new behavior?**
Use box-sizing: border-box for the Container, hence the paddings are incorporated into the actual width.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
**Additional Comments**
Ideally we should use global border-box box-sizing as the following. It will make the sizing more predictable.

However, introducing that at this stage kinda messes up the sizing of some layouts. We could have another PR to refactor it.

```
html {
  box-sizing: border-box;
}

*, *:before, *:after {
  box-sizing: inherit;
}
```

<!-- Thank you for contributing! -->
