### PR TITLE
Handle .prettierrc file at root

### DIFF
--- a/packages/app/src/app/containers/Preferences/CodeFormatting/Prettier.js
+++ b/packages/app/src/app/containers/Preferences/CodeFormatting/Prettier.js
@@ -44,6 +44,19 @@ class Prettier extends React.PureComponent {
     return (
       <Container>
         <PreferenceContainer>
+          <Description>
+            This configuration can be overridden by a{' '}
+            <a
+              href="https://prettier.io/docs/en/configuration.html"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              .prettierrc
+            </a>{' '}
+            JSON file at the root of the sandbox.
+          </Description>
+          <Rule />
+
           <PaddedPreference
             title="Print width"
             type="number"

--- a/packages/app/src/app/containers/Preferences/CodeFormatting/index.js
+++ b/packages/app/src/app/containers/Preferences/CodeFormatting/index.js
@@ -10,7 +10,7 @@ export default () => (
     <Title>
       Prettier Settings{' '}
       <a
-        href="https://github.com/prettier/prettier#options"
+        href="https://prettier.io/docs/en/options.html"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/packages/app/src/app/store/entities/sandboxes/actions/files.js
+++ b/packages/app/src/app/store/entities/sandboxes/actions/files.js
@@ -16,7 +16,6 @@ import { singleSandboxSelector } from '../selectors';
 import { normalizeResult } from '../../actions';
 import notificationActions from '../../../notifications/actions';
 import { preferencesSelector } from '../../../preferences/selectors';
-import preferencesActions from '../../../preferences/actions';
 
 import { maybeForkSandbox } from './fork';
 
@@ -388,37 +387,9 @@ const saveModuleCode = (id: string, moduleId: string) => async (
   dispatch(moduleActions.setCode(newModule.id, module.code));
 
   const preferences = preferencesSelector(getState());
-
-  // test if we are saving a root .prettierrc file
-  if (
-    newModule.title === '.prettierrc' &&
-    newModule.directoryShortid === null
-  ) {
-    let prettierConfig = null;
-    try {
-      prettierConfig = JSON.parse(module.code);
-    } catch (e) {
-      dispatch(
-        notificationActions.addNotification(
-          'Your Prettier config is not a valid JSON file',
-          'error'
-        )
-      );
-    }
-    // if we have a valid prettier config, we update the preferences with it
-    if (prettierConfig) {
-      dispatch(
-        preferencesActions.setPreference({
-          prettierConfig,
-        })
-      );
-    }
-  }
-
   if (preferences.prettifyOnSaveEnabled) {
     await dispatch(moduleActions.prettifyModule(newModule.id));
   }
-
   // For refresh of code we refetch the module
   newModule = singleModuleSelector(getState(), {
     sourceId,


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
It adds support for `.prettierrc` file placed at the root of the sandbox. It updates the Prettier preferences when the `.prettierrc` is saved.

Idea from @kentcdodds at https://twitter.com/kentcdodds/status/944817103814692864

Staging demo: http://pr419.cs.lbogdan.tk/s/rj733y8y6o

This is a kinda raw experiment but it's working fine so far but I already have some improvements in mind: 
- keep the default values for the keys not provided by the `.prettierrc` so the preferences UI is not broken. Like below for the "Tab width":
![image](https://user-images.githubusercontent.com/2678610/34326187-39ef55f8-e8a7-11e7-822a-b39bdf10f173.png)


