### PR TITLE
Fixes bug with dependencies having no 'versions' field

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/Dependencies/DependencyHit.js
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/Dependencies/DependencyHit.js
@@ -118,6 +118,15 @@ export default class DependencyHit extends React.PureComponent {
 
   render() {
     const { highlighted, hit, onClick } = this.props;
+
+    if (!hit.versions) {
+      if (hit.version) {
+        hit.versions = [hit.version];
+      } else {
+        return null;
+      }
+    }
+
     const versions = Object.keys(hit.versions);
     versions.reverse();
 


### PR DESCRIPTION
For some reason the `cq-demo` package has no 'versions' field, but it has a 'version', so we use that.
Fixes #435.