### PR TITLE
Fix expanding of devtools in the editor...

### DIFF
--- a/packages/app/src/app/components/sandbox/Preview/index.js
+++ b/packages/app/src/app/components/sandbox/Preview/index.js
@@ -55,7 +55,7 @@ type Props = {
   inactive: ?boolean,
   shouldExpandDevTools: ?boolean,
   entry: string,
-  devToolsOpen: ?boolean,
+  shouldExpandDevTools: ?boolean,
   setDevToolsOpen: ?(open: boolean) => void,
 };
 
@@ -448,7 +448,6 @@ export default class Preview extends React.PureComponent<Props, State> {
           sandboxId={sandboxId}
           shouldExpandDevTools={shouldExpandDevTools}
           zenMode={this.props.preferences.zenMode}
-          devToolsOpen={this.props.devToolsOpen}
           setDevToolsOpen={this.props.setDevToolsOpen}
         />
       </Container>

--- a/packages/app/src/app/pages/Sandbox/Editor/Content/index.js
+++ b/packages/app/src/app/pages/Sandbox/Editor/Content/index.js
@@ -47,7 +47,7 @@ import Skeleton from './Skeleton';
 type Props = {
   workspaceHidden: boolean,
   toggleWorkspace: () => void,
-  devToolsOpen: boolean,
+  shouldExpandDevTools: boolean,
   sandbox: Sandbox,
   user: CurrentUser,
   preferences: Preferences,
@@ -158,7 +158,7 @@ class EditorPreview extends React.PureComponent<Props, State> {
       toggleWorkspace,
       previewApiActions,
       viewActions,
-      devToolsOpen,
+      shouldExpandDevTools,
     } = this.props;
 
     const mainModule = findMainModule(modules, directories, sandbox.entry);
@@ -244,7 +244,7 @@ class EditorPreview extends React.PureComponent<Props, State> {
           inactive={this.state.resizing}
           entry={sandbox.entry}
           setDevToolsOpen={viewActions.setDevToolsOpen}
-          devToolsOpen={devToolsOpen}
+          shouldExpandDevTools={shouldExpandDevTools}
         />
       </FullSize>
     );

--- a/packages/app/src/app/pages/Sandbox/Editor/index.js
+++ b/packages/app/src/app/pages/Sandbox/Editor/index.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import SplitPane from 'react-split-pane';
 import type { Sandbox } from 'common/types';
+import { getSandboxOptions } from 'common/url';
 
 import Workspace from './Workspace';
 import Content from './Content';
@@ -17,6 +18,8 @@ type Props = {
 type State = {
   resizing: boolean,
 };
+
+const { expandDevTools } = getSandboxOptions(window.location.href);
 
 export default class ContentSplit extends React.PureComponent<Props, State> {
   state = {
@@ -55,6 +58,7 @@ export default class ContentSplit extends React.PureComponent<Props, State> {
           sandbox={sandbox}
           resizing={resizing}
           match={match}
+          shouldExpandDevTools={expandDevTools}
         />
       </SplitPane>
     );


### PR DESCRIPTION
…when url contains expanddevtools=1 parameter.

It's kinda naive, but it works.
