### PR TITLE
Fix: Limit the height of multiline input to Console Container's height

### DIFF
--- a/packages/app/src/app/components/sandbox/Preview/DevTools/Console/Input.js
+++ b/packages/app/src/app/components/sandbox/Preview/DevTools/Console/Input.js
@@ -22,6 +22,7 @@ const Container = styled.div`
   position: relative;
   height: ${props => props.height}px;
   min-height: 2rem;
+  max-height: 100%;
   width: 100%;
   background-color: ${props => props.theme.background.darken(0.3)};
   display: flex;


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
Bug fix

<!-- You can also link to an open issue here -->
**What is the current behavior?**
Style issues when Console's height is small, multiline input's monaco editor sets the input's height to be higher than console's height.

<!-- if this is a feature change -->
**What is the new behavior?**
Limit Console `<Input>`'s height to console `<Container>`'s height so when inserting new lines it doesn't overflow.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
