### PR TITLE
Fix duplicate dependency resolving

### DIFF
--- a/packages/app/src/sandbox/eval/npm/fetch-npm-module.js
+++ b/packages/app/src/sandbox/eval/npm/fetch-npm-module.js
@@ -30,19 +30,20 @@ export function getCombinedMetas() {
   return combinedMetas;
 }
 
-function normalize(depName: string, files: MetaFiles, fileObject: Meta = {}) {
+function normalize(
+  depName: string,
+  files: MetaFiles,
+  fileObject: Meta = {},
+  rootPath: string
+) {
   for (let i = 0; i < files.length; i += 1) {
     if (files[i].type === 'file') {
-      const absolutePath = pathUtils.join(
-        '/node_modules',
-        depName,
-        files[i].path
-      );
+      const absolutePath = pathUtils.join(rootPath, files[i].path);
       fileObject[absolutePath] = true; // eslint-disable-line no-param-reassign
     }
 
     if (files[i].files) {
-      normalize(depName, files[i].files, fileObject);
+      normalize(depName, files[i].files, fileObject, rootPath);
     }
   }
 
@@ -57,12 +58,7 @@ function getMeta(name: string, version: string) {
 
   metas[id] = window
     .fetch(`https://unpkg.com/${name}@${version}/?meta`)
-    .then(x => x.json())
-    .then(metaInfo => normalize(name, metaInfo.files))
-    .then(normalizedMetas => {
-      combinedMetas = { ...combinedMetas, ...normalizedMetas };
-      return normalizedMetas;
-    });
+    .then(x => x.json());
 
   return metas[id];
 }
@@ -73,7 +69,9 @@ function downloadDependency(depName: string, depVersion: string, path: string) {
   }
 
   const relativePath = path.replace(
-    pathUtils.join('/node_modules', depName),
+    new RegExp(
+      `.*${pathUtils.join('/node_modules', depName)}`.replace('/', '\\/')
+    ),
     ''
   );
 
@@ -99,42 +97,13 @@ function downloadDependency(depName: string, depVersion: string, path: string) {
   return packages[path];
 }
 
-function findDependencyVersion(manifest: Manifest, dependencyName: string) {
-  let version = null;
-
-  if (manifest.dependencyDependencies[dependencyName]) {
-    version = manifest.dependencyDependencies[dependencyName].resolved;
-  } else {
-    const dep = manifest.dependencies.find(m => m.name === dependencyName);
-
-    if (dep) {
-      version = dep.version;
-    }
-  }
-
-  if (version) {
-    return version;
-  }
-
-  return null;
-}
-
-export default async function fetchModule(
+function resolvePath(
   path: string,
   currentPath: string,
   manager: Manager,
-  defaultExtensions: Array<string> = ['js', 'jsx', 'json']
-): Promise<Module> {
-  const dependencyName = getDependencyName(path);
-
-  const version = findDependencyVersion(manager.manifest, dependencyName);
-
-  if (!version) {
-    throw new DependencyNotFoundError(path);
-  }
-
-  const meta = await getMeta(dependencyName, version);
-
+  defaultExtensions: Array<string> = ['js', 'jsx', 'json'],
+  meta = {}
+): Promise<string> {
   return new Promise((res, reject) => {
     resolve(
       path,
@@ -145,9 +114,14 @@ export default async function fetchModule(
           'node_modules',
           manager.envVariables.NODE_PATH,
         ].filter(x => x),
-        isFile: (p, c) => c(null, !!manager.transpiledModules[p] || !!meta[p]),
+        isFile: (p, c, cb) => {
+          const callback = cb || c;
+
+          callback(null, !!manager.transpiledModules[p] || !!meta[p]);
+        },
         readFile: async (p, c, cb) => {
           const callback = cb || c;
+
           if (manager.transpiledModules[p]) {
             return callback(null, manager.transpiledModules[p].module.code);
           }
@@ -155,12 +129,27 @@ export default async function fetchModule(
           const depPath = p.replace('/node_modules/', '');
           const depName = getDependencyName(depPath);
 
-          const subDepVersion = findDependencyVersion(
-            manager.manifest,
+          // We don't try to download package.json, because we can assume that
+          // all package.json files have been included in the bundle sent by
+          // the packager.
+          if (depPath.endsWith('package.json')) {
+            const err = new Error('Could not find ' + p);
+            err.code = 'ENOENT';
+
+            callback(err);
+            return null;
+          }
+
+          // eslint-disable-next-line
+          const subDepVersionVersionInfo = await findDependencyVersion(
+            currentPath,
+            manager,
+            defaultExtensions,
             depName
           );
 
-          if (subDepVersion) {
+          if (subDepVersionVersionInfo) {
+            const { version: subDepVersion } = subDepVersionVersionInfo;
             try {
               const module = await downloadDependency(
                 depName,
@@ -192,16 +181,107 @@ export default async function fetchModule(
           return reject(err);
         }
 
-        if (resolvedPath === '//empty.js') {
-          return res({
-            path: '//empty.js',
-            code: 'module.exports = {};',
-            requires: [],
-          });
-        }
-
-        return res(downloadDependency(dependencyName, version, resolvedPath));
+        return res(resolvedPath);
       }
     );
   });
+}
+
+async function findDependencyVersion(
+  currentPath: string,
+  manager: Manager,
+  defaultExtensions: Array<string> = ['js', 'jsx', 'json'],
+  dependencyName: string
+) {
+  const manifest = manager.manifest;
+
+  try {
+    const foundPackageJSONPath = await resolvePath(
+      pathUtils.join(dependencyName, 'package.json'),
+      currentPath,
+      manager,
+      defaultExtensions
+    );
+
+    const packageJSON =
+      manager.transpiledModules[foundPackageJSONPath] &&
+      manager.transpiledModules[foundPackageJSONPath].module.code;
+    const { version } = JSON.parse(packageJSON);
+
+    if (packageJSON !== '//empty.js') {
+      return { packageJSONPath: foundPackageJSONPath, version };
+    }
+  } catch (e) {
+    /* do nothing */
+  }
+
+  let version = null;
+
+  if (manifest.dependencyDependencies[dependencyName]) {
+    version = manifest.dependencyDependencies[dependencyName].resolved;
+  } else {
+    const dep = manifest.dependencies.find(m => m.name === dependencyName);
+
+    if (dep) {
+      version = dep.version;
+    }
+  }
+
+  if (version) {
+    return { packageJSONPath: null, version };
+  }
+
+  return null;
+}
+
+export default async function fetchModule(
+  path: string,
+  currentPath: string,
+  manager: Manager,
+  defaultExtensions: Array<string> = ['js', 'jsx', 'json']
+): Promise<Module> {
+  const dependencyName = getDependencyName(path);
+
+  const versionInfo = await findDependencyVersion(
+    currentPath,
+    manager,
+    defaultExtensions,
+    dependencyName
+  );
+
+  if (!versionInfo) {
+    throw new DependencyNotFoundError(path);
+  }
+
+  const { packageJSONPath, version } = versionInfo;
+
+  const meta = await getMeta(dependencyName, version);
+
+  const normalizedMeta = normalize(
+    dependencyName,
+    meta.files,
+    {},
+    packageJSONPath
+      ? pathUtils.dirname(packageJSONPath)
+      : pathUtils.join('/node_modules', dependencyName)
+  );
+  combinedMetas = { ...combinedMetas, ...normalizedMeta };
+
+  const foundPath = await resolvePath(
+    path,
+    currentPath,
+    manager,
+    defaultExtensions,
+    normalizedMeta
+  );
+
+  if (foundPath === '//empty.js') {
+    return {
+      path: '//empty.js',
+      code: 'module.exports = {};',
+      requires: [],
+    };
+  }
+
+  return downloadDependency(dependencyName, version, foundPath);
 }


### PR DESCRIPTION
Fixes the case where we can't find the right dependency version when dynamically fetching a dependency that's marked as subdependency (eg. `/node_modules/readable-stream/node_modules/string_decoder`). 

Fixes #444 