### PR TITLE
Update github regex for names containing a dash

### DIFF
--- a/packages/common/utils/url-generator.js
+++ b/packages/common/utils/url-generator.js
@@ -1,7 +1,7 @@
 // @flow
 import type { Sandbox } from 'common/types';
 
-export const gitHubRepoPattern = /(https?:\/\/)?((www.)?)github.com(\/\w+){2,}/;
+export const gitHubRepoPattern = /(https?:\/\/)?((www.)?)github.com(\/[\w-]+){2,}/;
 const gitHubPrefix = /(https?:\/\/)?((www.)?)github.com/;
 const dotGit = /(\.git)$/;
 


### PR DESCRIPTION
Update github regex for names containing a dash

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
Bug Fix

**What is the current behavior?**
Github regex currently fails if the username contains a dash `-`.

**What is the new behavior?**
Github regex passes if the username contains a dash `-`.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->