### PR TITLE
Add ability to enable the Cerebral debugger

### DIFF
--- a/packages/app/src/app/controller.js
+++ b/packages/app/src/app/controller.js
@@ -3,10 +3,16 @@ import store from './store';
 
 let Devtools = null;
 
-if (process.env.NODE_ENV !== 'production') {
+if (
+  process.env.NODE_ENV !== 'production' ||
+  (typeof window !== 'undefined' &&
+    'localStorage' in window &&
+    JSON.parse(window.localStorage.getItem('settings.connectDebugger')))
+) {
   Devtools = require('cerebral/devtools').default; // eslint-disable-line
 }
 
+// preferences.settings.${props`name`}
 export default Controller(store, {
   devtools:
     Devtools &&

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/EditorPageSettings/EditorSettings/index.js
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/EditorPageSettings/EditorSettings/index.js
@@ -65,6 +65,22 @@ function EditorSettings({ store, signals }) {
           </SubDescription>
           <Rule />
           <PaddedPreference
+            title="Cerebral Debugger"
+            type="boolean"
+            {...bindValue('connectDebugger')}
+          />
+          <SubDescription>
+            <a
+              href="https://cerebraljs.com/docs/introduction/debugger.html#debugger-install"
+              target="_new"
+            >
+              Download Cerebral debugger
+            </a>{' '}
+            and create an app on port <b>8383</b>. Refresh Codesandbox and get
+            insight into how it works
+          </SubDescription>
+          <Rule />
+          <PaddedPreference
             title="VIM mode"
             type="boolean"
             {...bindValue('vimMode')}

--- a/packages/app/src/app/store/modules/preferences/index.js
+++ b/packages/app/src/app/store/modules/preferences/index.js
@@ -7,6 +7,7 @@ export default Module({
   model,
   state: {
     settings: {
+      connectDebugger: false,
       prettifyOnSaveEnabled: true,
       zenMode: false,
       autoCompleteEnabled: true,

--- a/packages/app/src/app/store/modules/preferences/model.js
+++ b/packages/app/src/app/store/modules/preferences/model.js
@@ -2,6 +2,7 @@ import { types } from 'mobx-state-tree';
 
 export default {
   settings: types.model({
+    connectDebugger: types.boolean,
     prettifyOnSaveEnabled: types.boolean,
     autoCompleteEnabled: types.boolean,
     livePreviewEnabled: types.boolean,

--- a/packages/app/src/app/store/providers/SettingsStore.js
+++ b/packages/app/src/app/store/providers/SettingsStore.js
@@ -2,6 +2,7 @@ import store from 'store/dist/store.modern';
 import { Provider } from 'cerebral';
 
 const allowedKeys = {
+  connectDebugger: 'settings.connectDebugger',
   autoCompleteEnabled: 'settings.autocomplete',
   vimMode: 'settings.vimmode',
   livePreviewEnabled: 'settings.livepreview',


### PR DESCRIPTION
Gives the ability to enable the Cerebral debugger in production.

This can be used to help debugging the app, but also just very awesome being an open source project for developers :-)

