### PR TITLE
Error in Current Module View for TypeScript React Template

### DIFF
--- a/packages/app/src/sandbox/boilerplates/default-boilerplates.js
+++ b/packages/app/src/sandbox/boilerplates/default-boilerplates.js
@@ -13,6 +13,12 @@ export default function(module) {
 `,
 };
 
+export const TS = Object.assign(JS, {
+  id: 'ts',
+  extension: '.ts',
+  condition: '.tsx?$',
+})
+
 export const HTML = {
   id: 'html',
   extension: '.html',
@@ -24,4 +30,4 @@ export default function(module) {
 `,
 };
 
-export default [JS, HTML];
+export default [JS, TS, HTML];

--- a/packages/app/src/sandbox/boilerplates/default-boilerplates.js
+++ b/packages/app/src/sandbox/boilerplates/default-boilerplates.js
@@ -15,7 +15,6 @@ export default function(module) {
 
 export const TS = Object.assign(JS, {
   id: 'ts',
-  extension: '.ts',
   condition: '.tsx?$',
 })
 


### PR DESCRIPTION
https://codesandbox.io/s/react-ts

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**

Bug Fix

<!-- You can also link to an open issue here -->
**What is the current behavior?**

Currently, when I select "Current Module View" for Hello.tsx, I get the error: "Error No boilerplate found for /src/Hello.tsx, you can create one in the future".

<!-- if this is a feature change -->
**What is the new behavior?**

I would like to see the exported class from the module in the preview window. The code change I made is purely to demonstrate the goal, let me know if you feel something else would better resolve the error.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->

Thank you so much for CodeSandbox!