### PR TITLE
Fix HMR cache of parcel when first entry is changed

### DIFF
--- a/packages/app/src/sandbox/eval/presets/index.js
+++ b/packages/app/src/sandbox/eval/presets/index.js
@@ -142,7 +142,7 @@ export default class Preset {
    * Get transpilers from the given query, the query is webpack like:
    * eg. !babel-loader!./test.js
    */
-  getLoaders(module: Module, query: string = '') {
+  getLoaders(module: Module, query: string = ''): Array<TranspilerDefinition> {
     const loader = this.loaders.find(t => t.test(module));
 
     // Starting !, drop all transpilers

--- a/packages/app/src/sandbox/eval/presets/parcel/transpilers/html-transpiler.js
+++ b/packages/app/src/sandbox/eval/presets/parcel/transpilers/html-transpiler.js
@@ -11,7 +11,7 @@ class HTMLTranspiler extends WorkerTranspiler {
     this.HMREnabled = false;
   }
 
-  doTranspilation(code: string, loaderContext: LoaderContext) {
+  doTranspilation(code: string, loaderContext: LoaderContext): Promise<null> {
     return new Promise((resolve, reject) => {
       this.queueTask(
         {

--- a/packages/app/src/sandbox/eval/presets/parcel/transpilers/html-worker.js
+++ b/packages/app/src/sandbox/eval/presets/parcel/transpilers/html-worker.js
@@ -72,6 +72,7 @@ self.addEventListener('message', async event => {
       self.postMessage({
         type: 'add-dependency',
         path: assetPath,
+        isEntry: true,
       });
 
       resources.push(assetPath);

--- a/packages/app/src/sandbox/eval/transpiled-module.js
+++ b/packages/app/src/sandbox/eval/transpiled-module.js
@@ -19,7 +19,7 @@ import type { WarningStructure } from './transpilers/utils/worker-warning-handle
 import resolveDependency from './loaders/dependency-resolver';
 import evaluate from './loaders/eval';
 
-import type Manager from './manager';
+import type { default as Manager } from './manager';
 import HMR from './hmr';
 
 const debug = _debug('cs:compiler:transpiled-module');
@@ -97,12 +97,14 @@ export type LoaderContext = {
     depPath: string,
     options: ?{
       isAbsolute: boolean,
+      isEntry: boolean,
     }
   ) => void,
   addDependenciesInDirectory: (
     depPath: string,
     options: {
       isAbsolute: boolean,
+      isEntry: boolean,
     }
   ) => void,
   _module: TranspiledModule,
@@ -259,6 +261,7 @@ export default class TranspiledModule {
       if (this.compilation) {
         this.compilation = null;
       }
+
       Array.from(this.initiators)
         .filter(t => t.compilation)
         .forEach(dep => {
@@ -270,6 +273,16 @@ export default class TranspiledModule {
         .forEach(dep => {
           dep.resetCompilation();
         });
+
+      // If this is an entry we want all direct entries to be reset as well.
+      // Entries generally have side effects
+      if (this.isEntry) {
+        Array.from(this.dependencies)
+          .filter(t => t.compilation && t.isEntry)
+          .forEach(dep => {
+            dep.resetCompilation();
+          });
+      }
     }
   }
 
@@ -354,6 +367,10 @@ export default class TranspiledModule {
 
         this.transpilationDependencies.add(tModule);
         tModule.transpilationInitiators.add(this);
+
+        if (options.isEntry) {
+          tModule.setIsEntry(true);
+        }
       },
       addDependency: (depPath: string, options = {}) => {
         if (
@@ -371,6 +388,10 @@ export default class TranspiledModule {
 
           this.dependencies.add(tModule);
           tModule.initiators.add(this);
+
+          if (options.isEntry) {
+            tModule.setIsEntry(true);
+          }
         } catch (e) {
           if (e.type === 'module-not-found' && e.isDependency) {
             this.asyncDependencies.push(
@@ -388,7 +409,7 @@ export default class TranspiledModule {
           }
         }
       },
-      addDependenciesInDirectory: (folderPath: string, options) => {
+      addDependenciesInDirectory: (folderPath: string, options = {}) => {
         const tModules = manager.resolveTranspiledModulesInDirectory(
           folderPath,
           options && options.isAbsolute ? '/' : this.module.path
@@ -397,6 +418,10 @@ export default class TranspiledModule {
         tModules.forEach(tModule => {
           this.dependencies.add(tModule);
           tModule.initiators.add(this);
+
+          if (options.isEntry) {
+            tModule.setIsEntry(true);
+          }
         });
       },
       resolveTranspiledModule: (depPath: string, options = {}) =>
@@ -617,10 +642,8 @@ export default class TranspiledModule {
       ) {
         return this.compilation.exports;
       }
-    } else {
-      if (this.compilation && this.compilation.exports) {
-        return this.compilation.exports;
-      }
+    } else if (this.compilation && this.compilation.exports) {
+      return this.compilation.exports;
     }
 
     if (this.hmrConfig) {

--- a/packages/app/src/sandbox/eval/transpilers/worker-transpiler.js
+++ b/packages/app/src/sandbox/eval/transpilers/worker-transpiler.js
@@ -125,10 +125,12 @@ export default class WorkerTranspiler extends Transpiler {
           if (data.isGlob) {
             loaderContext.addDependenciesInDirectory(data.path, {
               isAbsolute: data.isAbsolute,
+              isEntry: data.isEntry,
             });
           } else {
             loaderContext.addDependency(data.path, {
               isAbsolute: data.isAbsolute,
+              isEntry: data.isEntry,
             });
           }
           return;
@@ -137,6 +139,7 @@ export default class WorkerTranspiler extends Transpiler {
         if (data.type === 'add-transpilation-dependency') {
           loaderContext.addTranspilationDependency(data.path, {
             isAbsolute: data.isAbsolute,
+            isEntry: data.isEntry,
           });
           return;
         }


### PR DESCRIPTION
If you'd change a style that is referenced by the HTML file then the browser would reset, because the JS was cached. This will bust the cache of all entries when an entry changes.