### PR TITLE
Fix Parcel HMR

### DIFF
--- a/packages/app/src/sandbox/eval/manager.js
+++ b/packages/app/src/sandbox/eval/manager.js
@@ -107,6 +107,7 @@ export default class Manager {
     this.webpackHMR = false;
     this.hardReload = false;
     this.hmrStatus = 'idle';
+    this.isFirstLoad = true;
     this.transpiledModulesByHash = {};
     this.configurations = {};
 
@@ -195,7 +196,7 @@ export default class Manager {
   }
 
   evaluateModule(module: Module, force: boolean = false) {
-    if (this.hardReload) {
+    if (this.hardReload && !this.isFirstLoad) {
       // Do a hard reload
       document.location.reload();
       return {};
@@ -600,6 +601,7 @@ export default class Manager {
   updateData(modules: { [path: string]: Module }) {
     this.transpileJobs = {};
     this.hardReload = false;
+    this.isFirstLoad = false;
 
     this.modules = modules;
 

--- a/packages/app/src/sandbox/eval/presets/parcel/transpilers/html-worker.js
+++ b/packages/app/src/sandbox/eval/presets/parcel/transpilers/html-worker.js
@@ -158,7 +158,8 @@ setupHTML();
   resources.forEach(resource => {
     const resourcePath = JSON.stringify(resource);
     compiledCode += `\n`;
-    compiledCode += `\trequire(${resourcePath});`;
+    compiledCode += `\trequire(${resourcePath});\n`;
+    compiledCode += `\tmodule.hot.accept(${resourcePath});`;
   });
   compiledCode += '\n}';
 

--- a/packages/app/src/sandbox/eval/presets/parcel/transpilers/html-worker.js
+++ b/packages/app/src/sandbox/eval/presets/parcel/transpilers/html-worker.js
@@ -72,7 +72,6 @@ self.addEventListener('message', async event => {
       self.postMessage({
         type: 'add-dependency',
         path: assetPath,
-        isEntry: true,
       });
 
       resources.push(assetPath);

--- a/packages/app/src/sandbox/eval/transpiled-module.js
+++ b/packages/app/src/sandbox/eval/transpiled-module.js
@@ -598,7 +598,7 @@ export default class TranspiledModule {
         .some(t => t.transpiler.HMREnabled);
 
       if (!hasHMR) {
-        manager.clearCompiledCache();
+        document.location.reload();
       } else {
         this.resetCompilation();
       }

--- a/packages/app/src/sandbox/eval/transpiled-module.js
+++ b/packages/app/src/sandbox/eval/transpiled-module.js
@@ -598,7 +598,7 @@ export default class TranspiledModule {
         .some(t => t.transpiler.HMREnabled);
 
       if (!hasHMR) {
-        document.location.reload();
+        manager.markHardReload();
       } else {
         this.resetCompilation();
       }


### PR DESCRIPTION
Fixes #644 by using the `module.hot` API to reload modules changed in the deeper levels of the dependency graph.