### PR TITLE
Indicate turning VIM mode on will enable CodeMirror

### DIFF
--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/EditorPageSettings/EditorSettings/index.js
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/EditorPageSettings/EditorSettings/index.js
@@ -80,7 +80,7 @@ function EditorSettings({ store, signals }) {
             {...bindValue('vimMode')}
           />
           <SubDescription>
-            This will override Use CodeMirror setting as Monaco doesn't have a VIM mode yet.
+            This will override Use CodeMirror setting as Monaco doesn{"'"}t have a VIM mode yet.
           </SubDescription>
           <Rule />
           <PaddedPreference

--- a/packages/app/src/app/pages/common/Modals/PreferencesModal/EditorPageSettings/EditorSettings/index.js
+++ b/packages/app/src/app/pages/common/Modals/PreferencesModal/EditorPageSettings/EditorSettings/index.js
@@ -79,6 +79,9 @@ function EditorSettings({ store, signals }) {
             type="boolean"
             {...bindValue('vimMode')}
           />
+          <SubDescription>
+            This will override Use CodeMirror setting as Monaco doesn't have a VIM mode yet.
+          </SubDescription>
           <Rule />
           <PaddedPreference
             title="Font size"


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
Bug fix

<!-- You can also link to an open issue here -->
**What is the current behavior?**
Switching the VIM mode setting on enables CodeMirror without notifying the user.

<!-- if this is a feature change -->
**What is the new behavior?**
It now indicates the current behavior.


<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
I have stumbled upon this when I started with a React Typescript sandbox but didn't see type errors I was expecting. I opened the same sandbox in a different browser to test and the errors were present there. At first, I thought it was a browser problem, but then I noticed the errors were gone after I switched the vim mode on there too. It was confusing.

The wording and detail are up to debate, but it should be indicated. A future improvement can be to make the CodeMirror option disabled at `on` state if VIM mode is selected. I don't know how long until Monaco gains vim support though, it may be too much work for little gain.
<!-- Thank you for contributing! -->
