### PR TITLE
Responsive console styles

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -122,7 +122,7 @@
     "codesandbox-import-utils": "^1.2.7",
     "color": "^0.11.4",
     "compare-versions": "^3.1.0",
-    "console-feed": "^2.5.0",
+    "console-feed": "^2.6.1",
     "css-modules-loader-core": "^1.1.0",
     "cssnano": "^3.10.0",
     "debug": "^2.6.8",


### PR DESCRIPTION
Upgrade to console-feed@2.6.1 - makes the console responsive, without overflowing containers.

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
Bug fix