### PR TITLE
feat: Allow users to add uploaded files to project

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/index.js
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/index.js
@@ -125,6 +125,7 @@ class DirectoryEntry extends React.Component {
         this.props.signals.files.fileUploaded({
           content: base64Image,
           name: file.name,
+          directoryShortid: this.props.shortid,
         });
       });
     };

--- a/packages/app/src/app/pages/common/Modals/StorageManagementModal/AddFileToSandboxButton/elements.js
+++ b/packages/app/src/app/pages/common/Modals/StorageManagementModal/AddFileToSandboxButton/elements.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import styled from 'styled-components';
+import AddIcon from 'react-icons/lib/md/add';
+import Tooltip from 'common/components/Tooltip';
+
+export const AddFileToSandboxButton = styled(props => (
+  <Tooltip title="Add File to Sandbox">
+    <button {...props}>
+      <AddIcon />
+    </button>
+  </Tooltip>
+))`
+  font-size: 1.2em;
+  background-color: inherit;
+  border: none;
+  padding: 5px 6px 9px 6px;
+  color: rgba(255, 255, 255, 0.5);
+  cursor: pointer;
+  &:hover {
+    color: rgba(255, 255, 255, 1);
+  }
+  &[disabled] {
+    opacity: 0.5;
+    cursor: default;
+  }
+`;

--- a/packages/app/src/app/pages/common/Modals/StorageManagementModal/AddFileToSandboxButton/index.js
+++ b/packages/app/src/app/pages/common/Modals/StorageManagementModal/AddFileToSandboxButton/index.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { AddFileToSandboxButton } from './elements';
+
+export default class AddFileToSandboxButtonContainer extends React.PureComponent {
+  addFileToSandbox = () => {
+    const { onAddFileToSandbox, url, name } = this.props;
+    onAddFileToSandbox({ url, name });
+  };
+
+  render() {
+    return <AddFileToSandboxButton onClick={this.addFileToSandbox} />;
+  }
+}

--- a/packages/app/src/app/pages/common/Modals/StorageManagementModal/FilesList/index.js
+++ b/packages/app/src/app/pages/common/Modals/StorageManagementModal/FilesList/index.js
@@ -3,9 +3,10 @@ import moment from 'moment';
 import { sortBy } from 'lodash';
 import filesize from 'filesize';
 import DeleteFileButton from '../DeleteFileButton';
+import AddFileToSandboxButton from '../AddFileToSandboxButton';
 import { HeaderTitle, Table, StatBody, Body, FileRow } from './elements';
 
-function FilesList({ files, deleteFile }) {
+function FilesList({ files, deleteFile, addFileToSandbox }) {
   return (
     <Table>
       <thead>
@@ -13,6 +14,7 @@ function FilesList({ files, deleteFile }) {
           <HeaderTitle>File</HeaderTitle>
           <HeaderTitle>Created</HeaderTitle>
           <HeaderTitle>Size</HeaderTitle>
+          <HeaderTitle />
           <HeaderTitle />
         </tr>
       </thead>
@@ -26,6 +28,13 @@ function FilesList({ files, deleteFile }) {
             </td>
             <td>{moment(f.insertedAt).format('ll')}</td>
             <td>{filesize(f.objectSize)}</td>
+            <StatBody style={{ padding: '0.55rem 0.5rem', cursor: 'pointer' }}>
+              <AddFileToSandboxButton
+                url={f.url}
+                name={f.name}
+                onAddFileToSandbox={addFileToSandbox}
+              />
+            </StatBody>
             <StatBody style={{ padding: '0.55rem 0.5rem', cursor: 'pointer' }}>
               <DeleteFileButton id={f.id} onDelete={deleteFile} />
             </StatBody>

--- a/packages/app/src/app/pages/common/Modals/StorageManagementModal/index.js
+++ b/packages/app/src/app/pages/common/Modals/StorageManagementModal/index.js
@@ -39,6 +39,7 @@ class StorageManagementModal extends React.Component {
             <FilesList
               files={store.uploadedFiles}
               deleteFile={signals.files.deletedUploadedFile}
+              addFileToSandbox={signals.files.addedFileToSandbox}
             />
           )}
         {isEmpty && (

--- a/packages/app/src/app/store/modules/files/index.js
+++ b/packages/app/src/app/store/modules/files/index.js
@@ -5,6 +5,7 @@ export default Module({
   model: {},
   state: {},
   signals: {
+    addedFileToSandbox: sequences.addFileToSandbox,
     gotUploadedFiles: sequences.getUploadedFiles,
     deletedUploadedFile: sequences.deleteUploadedFile,
     fileUploaded: sequences.uploadFile,

--- a/packages/app/src/app/store/modules/files/sequences.js
+++ b/packages/app/src/app/store/modules/files/sequences.js
@@ -61,6 +61,15 @@ export const createModule = [
   },
 ];
 
+export const addFileToSandbox = [
+  set(props`newCode`, props`url`),
+  set(props`title`, props`name`),
+  set(props`isBinary`, true),
+  closeModal,
+  set(state`uploadedFiles`, null),
+  createModule,
+];
+
 export const uploadFile = [
   set(props`modal`, 'uploading'),
   setModal,

--- a/packages/app/src/app/store/modules/files/sequences.js
+++ b/packages/app/src/app/store/modules/files/sequences.js
@@ -66,7 +66,6 @@ export const addFileToSandbox = [
   set(props`title`, props`name`),
   set(props`isBinary`, true),
   closeModal,
-  set(state`uploadedFiles`, null),
   createModule,
 ];
 


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
Feature:
There is a "+" button that will allow users to add uploaded files to the sandbox

<img width="650" alt="screen shot 2018-04-12 at 7 43 43 pm" src="https://user-images.githubusercontent.com/35270620/38714177-d92f43fc-3e89-11e8-93e6-8787e51f1ed6.png">

Fix: 
Allow users to upload files directly to directory via the buttons on the directories

<!-- You can also link to an open issue here -->
**What is the current behavior?**
Always uploads to the root directory

No way to put already uploaded files in sandbox if files are deleted from sandbox
<!-- if this is a feature change -->
**What is the new behavior?**
See picture.

Users and upload files to specified directories.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
