### PR TITLE
Add prop to override button rendering in OpenInCodeSandbox

### DIFF
--- a/packages/react-sandpack/src/components/OpenInCodeSandbox/OpenInCodeSandbox.tsx
+++ b/packages/react-sandpack/src/components/OpenInCodeSandbox/OpenInCodeSandbox.tsx
@@ -4,7 +4,11 @@ import { IFiles } from '../../types';
 
 import SandpackConsumer from '../SandpackConsumer';
 
-export default class OpenInCodeSandbox extends React.Component {
+export interface Props {
+  render?: () => React.ReactNode;
+}
+
+export default class OpenInCodeSandbox extends React.Component<Props> {
   getFileParameters = (files: IFiles) => {
     const normalized: {
       [path: string]: { content: string; isBinary: boolean };
@@ -22,7 +26,17 @@ export default class OpenInCodeSandbox extends React.Component {
     return getParameters({ files: normalized });
   };
 
+  renderButton() {
+    if (typeof this.props.render === 'function') {
+      return this.props.render();
+    }
+
+    return <input type="submit" value="Open in CodeSandbox" />;
+  }
+
   render() {
+    const { render, ...props } = this.props;
+
     return (
       <SandpackConsumer>
         {sandpack => (
@@ -30,14 +44,14 @@ export default class OpenInCodeSandbox extends React.Component {
             action="https://codesandbox.io/api/v1/sandboxes/define"
             method="POST"
             target="_blank"
-            {...this.props}
+            {...props}
           >
             <input
               type="hidden"
               name="parameters"
               value={this.getFileParameters(sandpack.files)}
             />
-            <input type="submit" value="Open in CodeSandbox" />
+            {this.renderButton()}
           </form>
         )}
       </SandpackConsumer>

--- a/packages/react-sandpack/stories/OpenInCodeSandbox.js
+++ b/packages/react-sandpack/stories/OpenInCodeSandbox.js
@@ -2,20 +2,36 @@ import React from 'react';
 import JSXAddon from 'storybook-addon-jsx';
 import { storiesOf, setAddon } from '@storybook/react';
 
+import SandpackProvider from '../src/components/SandpackProvider/index.ts';
 import OpenInCodeSandbox from '../src/components/OpenInCodeSandbox/index.ts';
 
 setAddon(JSXAddon);
 
 const stories = storiesOf('Export To CodeSandbox', module);
 
+stories.addWithJSX('minimal', () => (
+  <SandpackProvider
+    entry="/index.js"
+    files={{
+      '/index.js': {
+        code: '',
+      },
+    }}
+    dependencies={{}}
+  >
+    <OpenInCodeSandbox />
+  </SandpackProvider>
+));
+
 stories.addWithJSX('with multiple files', () => (
-  <OpenInCodeSandbox
+  <SandpackProvider
+    entry="/index.js"
     files={{
       '/index.js': {
         code: `import Hello from './Hello.js';
 
-document.body.innerHTML = JSON.stringify(Hello);
-`,
+  document.body.innerHTML = JSON.stringify(Hello);
+  `,
       },
       '/Hello.js': {
         code: `export default \`Hello from another file, here's an ID: $\{require('uuid')()}!\``,
@@ -24,5 +40,25 @@ document.body.innerHTML = JSON.stringify(Hello);
     dependencies={{
       uuid: 'latest',
     }}
-  />
+  >
+    <OpenInCodeSandbox />
+  </SandpackProvider>
+));
+
+stories.addWithJSX('with render prop', () => (
+  <SandpackProvider
+    entry="/index.js"
+    files={{
+      '/index.js': {
+        code: '',
+      },
+    }}
+    dependencies={{}}
+  >
+    <OpenInCodeSandbox
+      render={() => {
+        return <button type="submit">CodeSandbox is awesome!</button>;
+      }}
+    />
+  </SandpackProvider>
 ));


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
Allows overriding the rendering behavior in `OpenInCodeSandbox`.

<!-- You can also link to an open issue here -->
**What is the current behavior?**
Currently, the button is hardcoded to output `<input type="submit" />`.

<!-- if this is a feature change -->
**What is the new behavior?**


<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
Also, fixed up all the storybook examples with `OpenInCodeSandbox`

<!-- Thank you for contributing! -->
