### PR TITLE
Make babel transpiler options more consistent

### DIFF
--- a/packages/app/src/sandbox/eval/transpilers/babel/worker/babel-worker.js
+++ b/packages/app/src/sandbox/eval/transpilers/babel/worker/babel-worker.js
@@ -195,7 +195,7 @@ self.addEventListener('message', async event => {
     const transpilerOptions = event.data.babelTranspilerOptions;
     loadCustomTranspiler(
       transpilerOptions && transpilerOptions.babelURL,
-      transpilerOptions && transpilerOptions.babelEnvUrl
+      transpilerOptions && transpilerOptions.babelEnvURL
     );
     self.postMessage({
       type: 'result',
@@ -225,7 +225,7 @@ self.addEventListener('message', async event => {
 
   const babelUrl = babelTranspilerOptions && babelTranspilerOptions.babelURL;
   const babelEnvUrl =
-    babelTranspilerOptions && babelTranspilerOptions.babelEnvUrl;
+    babelTranspilerOptions && babelTranspilerOptions.babelEnvURL;
 
   if (babelUrl || babelEnvUrl) {
     loadCustomTranspiler(babelUrl, babelEnvUrl);


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
Currently, `babel-transpiler.json` has two inconsistently named options: `babelURL` vs `babelEnvUrl`.

<!-- You can also link to an open issue here -->
**What is the current behavior?**

<!-- if this is a feature change -->
**What is the new behavior?**
`babelEnvUrl` -> `babelEnvURL`

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
