### PR TITLE
Fix vue-cli @ alias

### DIFF
--- a/packages/app/src/sandbox/eval/presets/vue-cli/index.js
+++ b/packages/app/src/sandbox/eval/presets/vue-cli/index.js
@@ -39,7 +39,7 @@ export default function initialize() {
     'vue-cli',
     ['vue', 'json', 'js'],
     {
-      '@': '{{sandboxRoot}}',
+      '@': '{{sandboxRoot}}/src',
       vue$: 'vue/dist/vue.common.js',
     },
     {


### PR DESCRIPTION
This was pretty much broken from the get-go, strangely enough no one noticed. :smile: As seen here https://github.com/vuejs-templates/webpack/blob/develop/template/build/webpack.base.conf.js#L40 , `@` should point to `/src`, not `/`.