### PR TITLE
Fallback to looking for .ts files if no .d.ts files found

### DIFF
--- a/packages/app/src/app/components/CodeEditor/Monaco/workers/fetch-dependency-typings.js
+++ b/packages/app/src/app/components/CodeEditor/Monaco/workers/fetch-dependency-typings.js
@@ -173,15 +173,19 @@ function fetchFromMeta(dependency, version, fetchedPaths) {
   return doFetch(depUrl)
     .then(response => JSON.parse(response))
     .then(meta => {
-      const filterAndFlatten = files =>
+      const filterAndFlatten = (files, filter) =>
         files.reduce((paths, file) => {
-          if (/\.d\.ts$/.test(file.name)) {
+          if (filter.test(file.name)) {
             paths.push(file.name);
           }
           return paths;
         }, []);
 
-      const dtsFiles = filterAndFlatten(meta.files);
+      let dtsFiles = filterAndFlatten(meta.files, /\.d\.ts$/);
+      if (dtsFiles.length === 0) {
+        // if no .d.ts files found, fallback to .ts files
+        dtsFiles = filterAndFlatten(meta.files, /\.ts$/);
+      }
 
       if (dtsFiles.length === 0) {
         throw new Error('No inline typings found.');


### PR DESCRIPTION
Fixes #559 .

Test: http://pr811.cs.lbogdan.tk/s/kkpplyrqqo , go to `src/app/app.module.ts`, there's no `Cannot find module 'angular-bootstrap-md'.` error.