### PR TITLE
[Feature] WIP: Keybindings added to navigate between tabs.

### DIFF
--- a/packages/app/src/app/store/modules/editor/actions.js
+++ b/packages/app/src/app/store/modules/editor/actions.js
@@ -370,3 +370,24 @@ export function setPreviewBounds({ props, state }) {
     state.set(`editor.previewWindow.height`, props.height);
   }
 }
+
+export function switchToTab({ state, props }) {
+  const tabs = state.get('editor.tabs');
+
+  const currentModuleShortid = state.get(`editor.currentModuleShortid`);
+  const currentTabIndex = tabs.findIndex(
+    t => t.moduleShortid === currentModuleShortid
+  );
+
+  const switchToTabIndex = (tabLength, currentIdx) => {
+    if (props.shouldSwitchNext) {
+      return currentIdx >= tabLength ? 0 : currentIdx + 1;
+    }
+    return currentIdx <= 0 ? tabs.length - 1 : currentIdx - 1;
+  };
+
+  const index = switchToTabIndex(tabs.length - 1, currentTabIndex);
+  const moduleShortid = state.get(`editor.tabs.${index}.moduleShortid`);
+
+  state.set('editor.currentModuleShortid', moduleShortid);
+}

--- a/packages/app/src/app/store/modules/editor/index.js
+++ b/packages/app/src/app/store/modules/editor/index.js
@@ -85,5 +85,6 @@ export default Module({
     quickActionsClosed: sequences.closeQuickActions,
     setPreviewBounds: sequences.setPreviewBounds,
     setPreviewContent: sequences.setPreviewContent,
+    switchTab: sequences.switchTab,
   },
 });

--- a/packages/app/src/app/store/modules/editor/sequences.js
+++ b/packages/app/src/app/store/modules/editor/sequences.js
@@ -34,6 +34,14 @@ export const closeTab = [
   },
 ];
 
+export const switchTab = [
+  hasEnoughTabs,
+  {
+    false: [],
+    true: [actions.switchToTab],
+  },
+];
+
 export const clearErrors = [
   set(state`editor.errors`, []),
   set(state`editor.corrections`, []),

--- a/packages/common/utils/keybindings.js
+++ b/packages/common/utils/keybindings.js
@@ -69,6 +69,22 @@ export const KEYBINDINGS = {
     }),
   },
 
+  'editor.switch-next-tab': {
+    title: 'Switch Next Tab',
+    type: 'View',
+    bindings: [['Control', 'S']],
+    signal: 'editor.switchTab',
+    payload: () => ({ shouldSwitchNext: true }),
+  },
+
+  'editor.switch-previous-tab': {
+    title: 'Switch Previous Tab',
+    type: 'View',
+    bindings: [['Control', 'Z']],
+    signal: 'editor.switchTab',
+    payload: () => ({ shouldSwitchNext: false }),
+  },
+
   'editor.zen-mode': {
     title: 'Toggle Zen Mode',
     type: 'View',

--- a/packages/common/utils/keybindings.js
+++ b/packages/common/utils/keybindings.js
@@ -70,7 +70,7 @@ export const KEYBINDINGS = {
   },
 
   'editor.switch-next-tab': {
-    title: 'Switch Next Tab',
+    title: 'Switch To Next Tab',
     type: 'View',
     bindings: [['Control', 'S']],
     signal: 'editor.switchTab',
@@ -78,7 +78,7 @@ export const KEYBINDINGS = {
   },
 
   'editor.switch-previous-tab': {
-    title: 'Switch Previous Tab',
+    title: 'Switch To Previous Tab',
     type: 'View',
     bindings: [['Control', 'Z']],
     signal: 'editor.switchTab',


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
This feature introduces two new keybindings:
`Switch To Next Tab` & `Switch To Previous Tab`

![switchtabdemo](https://user-images.githubusercontent.com/6424060/39821239-11e269e4-53a8-11e8-8f86-be33b82dbbb3.gif)


<!-- You can also link to an open issue here -->
**What is the current behavior?**
See #761 

<!-- if this is a feature change -->
**What is the new behavior?**

`Switch To Next Tab:` Keybinding allowing users to create a shortcut to switch to the next tab

`Switch To Previous Tab:` Keybinding allowing users to create a shortcut to switch to the previous tab

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation __N/A__
- [ ] Tests __N/A__
- [ ] Ready to be merged __N/A__ <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table __N/A__ <!-- this is optional, see the contributing guidelines for instructions -->

**Additional comments**
I have introduced the functionality to switch between tabs in both directions. When testing the PR it seems I ran into a few _snags:_

1) I found it hard to find appropriate default keybinding values that worked, as some were taken by the browser. Open to suggestions here as to what they should be and if they should be able to overwrite browser defaults?

2) Also in terms of usability if a keybinding was created with multiple keys eg. `Control + S` after the first execution I would expect the keybinding to still execute if the user held `Control` and repeatedly pressed `S`, currently this is not the situation.  To switch to the next tab the user has to repeatedly press `Control + S`

**Please Note**:  _The default keybindings in the PR are not final they were just used for testing purposes and can be changed to more appropriate keys_