### PR TITLE
fix: wrong use of addEventListener/removeEventListener

### DIFF
--- a/packages/app/src/app/components/ContextMenu/index.js
+++ b/packages/app/src/app/components/ContextMenu/index.js
@@ -12,10 +12,7 @@ class ContextMenu extends React.Component {
       y: 0,
       show: false,
     };
-  }
-  onContextMenu = event => {
-    event.preventDefault();
-    this.mousedown = window.addEventListener('mousedown', mousedownEvent => {
+    this.mousedownCb = mousedownEvent => {
       const { show } = this.state;
 
       if (show && this.el) {
@@ -23,15 +20,19 @@ class ContextMenu extends React.Component {
           this.close();
         }
       }
-    });
-
-    this.keydown = window.addEventListener('keydown', keydownEvent => {
+    };
+    this.keydownCb = keydownEvent => {
       const { show } = this.state;
       if (keydownEvent.keyCode === 27 && show) {
         // Escape
         this.close();
       }
-    });
+    };
+  }
+  onContextMenu = event => {
+    event.preventDefault();
+    window.addEventListener('mousedown', this.mousedownCb);
+    window.addEventListener('keydown', this.keydownCb);
 
     this.setState({
       show: true,
@@ -41,8 +42,8 @@ class ContextMenu extends React.Component {
   };
 
   close = () => {
-    window.removeEventListener('keydown', this.keydown);
-    window.removeEventListener('mousedown', this.mousedown);
+    window.removeEventListener('keydown', this.keydownCb);
+    window.removeEventListener('mousedown', this.mousedownCb);
     this.setState({
       show: false,
     });


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**

`addEventListener` just return `undefined` not `Function`;
https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener


<!-- You can also link to an open issue here -->
**What is the current behavior?**

<!-- if this is a feature change -->
**What is the new behavior?**

Same as before;

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
