### PR TITLE
Recover wave animation after tabs switch

### DIFF
--- a/packages/homepage/src/screens/home/Animation/canvas/index.js
+++ b/packages/homepage/src/screens/home/Animation/canvas/index.js
@@ -68,6 +68,8 @@ class Canvas {
 
       if (renderDelta > 4000) {
         this.lowPerf = true;
+      } else {
+        this.lowPerf = false;
       }
 
       let distX;


### PR DESCRIPTION
After switch tabs wave animations will stop. Reset variable lowPerf to false to recover it when tab regain focus.
