### PR TITLE
fix(actions): set preferences showDevTools

### DIFF
--- a/packages/app/src/app/store/actions.js
+++ b/packages/app/src/app/store/actions.js
@@ -84,7 +84,7 @@ export function setUrlOptions({ state, router, utils }) {
   if (options.forceRefresh)
     state.set('preferences.settings.forceRefresh', options.forceRefresh);
   if (options.expandDevTools)
-    state.set('preferences.showConsole', options.expandDevTools);
+    state.set('preferences.showDevtools', options.expandDevTools);
   if (options.runOnClick)
     state.set(`preferences.runOnClick`, options.runOnClick);
 }


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
Bug fix. Closes #353.

<!-- You can also link to an open issue here -->
**What is the current behavior?**
#353 - When you enable "Expand console" it should save in `preferences.showDevtools`, however, it saved as `preferences.showConsole`.

<!-- if this is a feature change -->
**What is the new behavior?**
It saves on store as `preferences.showDevtools` which is expected in _Content_.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
