### PR TITLE
fix(sandbox): Fixing loading of sandbox when a module is informed but…

### DIFF
--- a/packages/app/src/app/store/actions.js
+++ b/packages/app/src/app/store/actions.js
@@ -38,20 +38,34 @@ export function setUrlOptions({ state, router, utils }) {
 
   if (options.currentModule) {
     const sandbox = state.get('editor.currentSandbox');
-    const module = utils.resolveModule(
-      options.currentModule,
-      sandbox.modules,
-      sandbox.directories,
-      options.currentModule.directoryShortid
-    );
 
-    if (module) {
-      state.push('editor.tabs', {
-        type: 'module',
-        moduleShortid: module.shortid,
-        dirty: false,
+    try {
+      const module = utils.resolveModule(
+        options.currentModule,
+        sandbox.modules,
+        sandbox.directories,
+        options.currentModule.directoryShortid
+      );
+
+      if (module) {
+        state.push('editor.tabs', {
+          type: 'module',
+          moduleShortid: module.shortid,
+          dirty: false,
+        });
+        state.set('editor.currentModuleShortid', module.shortid);
+      }
+    } catch (err) {
+      const now = Date.now();
+      const title = `Could not find the module ${options.currentModule}`;
+
+      state.push('notifications', {
+        title,
+        id: now,
+        notificationType: 'warning',
+        endTime: now + 2000,
+        buttons: [],
       });
-      state.set('editor.currentModuleShortid', module.shortid);
     }
   }
 


### PR DESCRIPTION
… doesn't exist

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
Bug fix. Closes #920.
<!-- You can also link to an open issue here -->
**What is the current behavior?**
See #920.
<!-- if this is a feature change -->
**What is the new behavior?**
When a module is informed but doesn't exist, the loading is resolved as if a module wasn't informed and a notification of type 'warning' is shown saying that the module couldn't been found.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
