### PR TITLE
Fix app dependency loader error

### DIFF
--- a/packages/app/src/sandbox/npm/index.js
+++ b/packages/app/src/sandbox/npm/index.js
@@ -22,7 +22,7 @@ export default async function loadDependencies(dependencies: NPMDependencies) {
     // We filter out all @types, as they are not of any worth to the bundler
     const dependenciesWithoutTypings = pickBy(
       dependencies,
-      (val, key) => !key.includes('@types')
+      (val, key) => !(key.includes && key.includes('@types'))
     );
 
     const depQuery = dependenciesToQuery(dependenciesWithoutTypings);


### PR DESCRIPTION
## Purpose

**Bug Fix**

The dependency loader excludes dependencies for types by checking that the keys of a dependency object do not include the string `"@types"`.

The helper `pickBy` eventually calls `getAllKeys` which gets symbols up the prototype chain in addition to keys on the object.

When a package introduces symbols to the `Object.prototype`, the type check fails when the document is reloaded because symbols do not have an `includes` method (`key.includes is not a function`)

**To Reproduce**
1. Create a new sandbox
2. Add "funcadelic" to dependencies
3. `import "funcadelic"` in the index
4. Wait for dependencies to build
5. Making any changes displays the error

**Link to existing sandbox with bug:** https://codesandbox.io/s/wozkol0n7

## Approach

Check that `key.includes` is defined before calling it when filtering out `"@types"` dependencies.

**Checklist**

- [ ] Documentation `N/A`
- [ ] Tests `N/A` - the only tests I see are for screenshots
- [x] Ready to be merged
- [ ] Added myself to contributors table

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
