### PR TITLE
refactor styled-components extend style

### DIFF
--- a/packages/app/src/app/components/HeaderSearchBar/elements.js
+++ b/packages/app/src/app/components/HeaderSearchBar/elements.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import SearchIcon from 'react-icons/lib/go/search';
 import Relative from 'common/components/Relative';
 
-export const Container = styled(Relative)`
+export const Container = Relative.extend`
   display: flex;
   align-items: center;
   font-weight: 500;

--- a/packages/app/src/app/components/ModeIcons/elements.js
+++ b/packages/app/src/app/components/ModeIcons/elements.js
@@ -102,10 +102,10 @@ const Icon = styled.div`
   height: 100%;
 `;
 
-export const EditorIcon = styled(Icon)`
+export const EditorIcon = Icon.extend`
   background-color: ${({ theme }) => theme.templateColor || theme.secondary};
 `;
 
-export const PreviewIcon = styled(Icon)`
+export const PreviewIcon = Icon.extend`
   background-color: ${({ theme }) => theme.primary};
 `;

--- a/packages/app/src/app/components/NewSandbox/elements.js
+++ b/packages/app/src/app/components/NewSandbox/elements.js
@@ -8,7 +8,7 @@ export const Container = styled.div`
   background-color: ${props => props.theme.background};
 `;
 
-export const RowContainer = styled(Row)`
+export const RowContainer = Row.extend`
   justify-content: center;
   color: rgba(255, 255, 255, 0.8);
   padding-top: 1.5rem;

--- a/packages/app/src/app/components/SandboxList/elements.js
+++ b/packages/app/src/app/components/SandboxList/elements.js
@@ -15,7 +15,7 @@ export const Table = styled.table`
   margin-bottom: 2rem;
 `;
 
-export const StatTitle = styled(HeaderTitle)`
+export const StatTitle = HeaderTitle.extend`
   width: 2rem;
   text-align: center;
 `;

--- a/packages/app/src/app/components/SubscribeForm/CheckoutForm/elements.js
+++ b/packages/app/src/app/components/SubscribeForm/CheckoutForm/elements.js
@@ -8,7 +8,7 @@ export const CardContainer = styled.div`
   border-radius: 4px;
 `;
 
-export const NameInput = styled(Input)`
+export const NameInput = Input.extend`
   width: 100%;
   font-size: 0.875rem;
   padding: 0.5rem;

--- a/packages/app/src/app/pages/CliInstructions/elements.js
+++ b/packages/app/src/app/pages/CliInstructions/elements.js
@@ -7,7 +7,7 @@ export const Container = styled.div`
   margin: 1rem;
 `;
 
-export const Content = styled(Centered)`
+export const Content = Centered.extend`
   max-width: 50em;
   margin: auto;
   margin-top: 10%;

--- a/packages/app/src/app/pages/GitHub/elements.js
+++ b/packages/app/src/app/pages/GitHub/elements.js
@@ -8,7 +8,7 @@ export const Container = styled.div`
   margin: 1rem;
 `;
 
-export const Content = styled(Centered)`
+export const Content = Centered.extend`
   max-width: 50em;
   margin: auto;
   margin-top: 10%;
@@ -25,7 +25,7 @@ export const Description = styled.div`
   margin-bottom: 1rem;
 `;
 
-export const StyledInput = styled(Input)`
+export const StyledInput = Input.extend`
   font-size: 1.25rem;
   margin-bottom: 2rem;
 `;

--- a/packages/app/src/app/pages/Patron/PricingModal/PricingChoice/elements.js
+++ b/packages/app/src/app/pages/Patron/PricingModal/PricingChoice/elements.js
@@ -6,7 +6,7 @@ export const Container = styled.div`
   padding: 1rem 0;
 `;
 
-export const PriceInput = styled(Input)`
+export const PriceInput = Input.extend`
   font-size: 1.5rem;
   padding-left: 2rem;
   padding-right: 1rem;

--- a/packages/app/src/app/pages/Profile/Navigation/elements.js
+++ b/packages/app/src/app/pages/Profile/Navigation/elements.js
@@ -25,6 +25,6 @@ export const NavigationLink = styled(NavLink)`
   }
 `;
 
-export const CenteredRow = styled(Row)`
+export const CenteredRow = Row.extend`
   width: 100%;
 `;

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Live/LiveInfo.js
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Live/LiveInfo.js
@@ -43,7 +43,7 @@ const Title = styled.div`
   }
 `;
 
-const StyledInput = styled(Input)`
+const StyledInput = Input.extend`
   width: calc(100% - 1.5rem);
   margin: 0 0.75rem;
   font-size: 0.875rem;

--- a/packages/app/src/app/pages/Search/elements.js
+++ b/packages/app/src/app/pages/Search/elements.js
@@ -7,7 +7,7 @@ export const Content = styled.div`
   color: white;
 `;
 
-export const StyledTitle = styled(Title)`
+export const StyledTitle = Title.extend`
   display: inline-block;
   text-align: left;
   font-size: 2rem;

--- a/packages/app/src/app/pages/common/UserMenu/elements.js
+++ b/packages/app/src/app/pages/common/UserMenu/elements.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import Row from 'common/components/flex/Row';
 
-export const ClickableContainer = styled(Row)`
+export const ClickableContainer = Row.extend`
   cursor: pointer;
 `;
 

--- a/packages/common/components/Preference/elements.js
+++ b/packages/common/components/Preference/elements.js
@@ -7,6 +7,6 @@ export const Container = styled.div`
   align-items: center;
 `;
 
-export const StyledInput = styled(Input)`
+export const StyledInput = Input.extend`
   text-align: center;
 `;

--- a/packages/homepage/src/screens/home/Frameworks/index.js
+++ b/packages/homepage/src/screens/home/Frameworks/index.js
@@ -79,7 +79,7 @@ const Flex = styled.div`
   `};
 `;
 
-const Intro = styled(Column)`
+const Intro = Column.extend`
   flex: 1;
 
   ${media.phone`


### PR DESCRIPTION
You should only use Comp.extend if you know that Comp is a styled component. If you're importing from another file or a third party library, prefer to use styled(Comp) as it accomplishes the same thing but works with any React component. 

**Behind the scenes**

The styled() factory generates new component styles with a new class. The classnames are then passed to the React component via the className prop. Calling extend creates new component styles by extending the old one, and thus doesn't generate two classes for a single component. (styled() factory does that)

