### PR TITLE
feat(themes): add cobalt2

### DIFF
--- a/packages/common/themes/index.js
+++ b/packages/common/themes/index.js
@@ -36,6 +36,12 @@ export default [
     get: () => import('./vscode-light'),
   },
   {
+    name: 'Cobalt 2',
+    id: 'cobalt2',
+    url:
+      'https://raw.githubusercontent.com/wesbos/cobalt2-vscode/master/theme/cobalt2.json',
+  },
+  {
     name: 'Atom Light',
     id: 'atomLight',
     url:

--- a/packages/common/themes/index.js
+++ b/packages/common/themes/index.js
@@ -39,7 +39,7 @@ export default [
     name: 'Cobalt 2',
     id: 'cobalt2',
     url:
-      'https://raw.githubusercontent.com/wesbos/cobalt2-vscode/master/theme/cobalt2.json',
+      'https://cdn.rawgit.com/wesbos/cobalt2-vscode/master/theme/cobalt2.json',
   },
   {
     name: 'Atom Light',


### PR DESCRIPTION

Seems like there's an issue with comments still, error message isn't totally clear to me:

```
We had trouble parsing your custom VSCode Theme, error: Expected ':' instead of '"' at line 7 column 5 of the JSON5 data. Still to read: "\"activityBar.backgro"
```

Error message is one off with the comment, so I think if we strip those first, it should be fine

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**

add Cobalt2 to default themes (cc @wesbos)


<!-- You can also link to an open issue here -->
**What is the current behavior?**

fixes #965


<!-- if this is a feature change -->
**What is the new behavior?**

New default theme


<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
