### PR TITLE
fix(genie): allow genie to sort wishes properly

### DIFF
--- a/packages/app/src/app/pages/Sandbox/QuickActions/index.js
+++ b/packages/app/src/app/pages/Sandbox/QuickActions/index.js
@@ -78,8 +78,15 @@ class QuickActions extends React.Component {
   }
 
   loadGenie() {
-    const { enteredMagicWords } = JSON.parse(window.localStorage.getItem('genie'))
-    genie.options({ enteredMagicWords })
+    try {    
+      const { enteredMagicWords } = JSON.parse(window.localStorage.getItem('genie'))
+      genie.options({ enteredMagicWords })
+    } catch (error) {
+      // it may not exist in localStorage yet, or the JSON was malformed somehow
+      // so we'll persist it to update localStorage so it doesn't throw an error
+      // next time the page is loaded.
+      this.persistGenie()
+    }
   }
 
   itemToString = item => item && item.magicWords.join(', ');

--- a/packages/app/src/app/pages/Sandbox/QuickActions/index.js
+++ b/packages/app/src/app/pages/Sandbox/QuickActions/index.js
@@ -114,7 +114,9 @@ class QuickActions extends React.Component {
             highlightedIndex,
           }) => {
             const inputProps = getInputProps({
-              onChange: ev => this.inputValue = ev.target.value,
+              onChange: ev => {
+                this.inputValue = ev.target.value
+              },
               innerRef: el => el && el.focus(),
               onKeyUp: this.handleKeyUp,
               // Timeout so the fuzzy handler can still select the module

--- a/packages/app/src/app/pages/Sandbox/QuickActions/index.js
+++ b/packages/app/src/app/pages/Sandbox/QuickActions/index.js
@@ -62,8 +62,8 @@ class QuickActions extends React.Component {
     this.props.signals.editor.quickActionsClosed();
   };
 
-  onChange = item => {
-    genie.makeWish(item);
+  onChange = (item, { inputValue }) => {
+    genie.makeWish(item, inputValue);
     this.closeQuickActions();
   };
 

--- a/packages/app/src/app/pages/Sandbox/QuickActions/index.js
+++ b/packages/app/src/app/pages/Sandbox/QuickActions/index.js
@@ -16,6 +16,9 @@ import {
 } from './elements';
 
 class QuickActions extends React.Component {
+  // we'll just keep track of what the user changes the inputValue to be
+  // so when the user makes a wish we can provide that info to genie
+  inputValue = ''
   updateGenie = () => {
     const keybindings = this.props.store.preferences.keybindings;
     const signals = this.props.signals;
@@ -62,8 +65,8 @@ class QuickActions extends React.Component {
     this.props.signals.editor.quickActionsClosed();
   };
 
-  onChange = (item, { inputValue }) => {
-    genie.makeWish(item, inputValue);
+  onChange = item => {
+    genie.makeWish(item, this.inputValue);
     this.closeQuickActions();
   };
 
@@ -92,6 +95,7 @@ class QuickActions extends React.Component {
             highlightedIndex,
           }) => {
             const inputProps = getInputProps({
+              onChange: ev => this.inputValue = ev.target.value,
               innerRef: el => el && el.focus(),
               onKeyUp: this.handleKeyUp,
               // Timeout so the fuzzy handler can still select the module

--- a/packages/app/src/app/pages/Sandbox/QuickActions/index.js
+++ b/packages/app/src/app/pages/Sandbox/QuickActions/index.js
@@ -47,6 +47,7 @@ class QuickActions extends React.Component {
 
   componentDidMount() {
     this.updateGenie();
+    this.loadGenie();
   }
 
   componentDidUpdate() {
@@ -67,8 +68,19 @@ class QuickActions extends React.Component {
 
   onChange = item => {
     genie.makeWish(item, this.inputValue);
+    this.persistGenie();
     this.closeQuickActions();
   };
+
+  persistGenie() {
+    const { enteredMagicWords } = genie.options();
+    window.localStorage.setItem('genie', JSON.stringify({ enteredMagicWords }))
+  }
+
+  loadGenie() {
+    const { enteredMagicWords } = JSON.parse(window.localStorage.getItem('genie'))
+    genie.options({ enteredMagicWords })
+  }
 
   itemToString = item => item && item.magicWords.join(', ');
 


### PR DESCRIPTION
One of the cool things about genie is it's sorting algorithm takes into account the user's previous choices. By providing the input value when you make the wish, genie can keep track of what input values lead to which wishes and can optimistically suggest certain wishes as the user's typing.

**What kind of change does this PR introduce?** Bug Fix

**What is the current behavior?** genie isn't able to make proper suggestions based on previous wishes made

<!-- if this is a feature change -->
**What is the new behavior?** genie will optimistically suggest wishes

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions --> I should probably do this... 😅 But feel free to merge before I get the chance.

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
