### PR TITLE
Fix async issue with fetching typings from meta Fixes #1021

### DIFF
--- a/packages/app/src/app/components/CodeEditor/Monaco/workers/fetch-dependency-typings.js
+++ b/packages/app/src/app/components/CodeEditor/Monaco/workers/fetch-dependency-typings.js
@@ -191,13 +191,13 @@ function fetchFromMeta(dependency, version, fetchedPaths) {
         throw new Error('No inline typings found.');
       }
 
-      dtsFiles.forEach(file => {
+      return Promise.all(dtsFiles.map(file =>
         doFetch(`https://cdn.jsdelivr.net/npm/${dependency}@${version}${file}`)
           .then(dtsFile =>
             addLib(`node_modules/${dependency}${file}`, dtsFile, fetchedPaths)
           )
-          .catch(() => {});
-      });
+          .catch(() => {})
+      ));
     });
 }
 


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
Ensure that all fetch Promises have been resolved when returning from the fetchFromMeta method in fetch-dependency-typings.

<!-- You can also link to an open issue here -->
**What is the current behavior?**
Currently, it causes inconsistencies when it comes to fetching inline typings as the promise can resolve before all of the types are downloaded.

<!-- if this is a feature change -->
**What is the new behavior?**
The new fix causes the `fetchFromMeta` to return a `Promise.all` of its fetch calls to ensure its returned Promise doesn't resolve until all of them do.


<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation (NA)
- [ ] Tests (skipped as I didn't see existing tests for this file
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
