### PR TITLE
Add (le|sa|sc)ss and styl file types to list of forced text extensions.

### DIFF
--- a/packages/app/src/app/store/modules/files/actions.js
+++ b/packages/app/src/app/store/modules/files/actions.js
@@ -71,6 +71,10 @@ export async function uploadFiles({ api, props, path }) {
               /\.json$/.test(filePath) ||
               /\.html$/.test(filePath) ||
               /\.vue$/.test(filePath) ||
+              /\.styl$/.test(filePath) ||
+              /\.less$/.test(filePath) ||
+              /\.scss$/.test(filePath) ||
+              /\.sass$/.test(filePath) ||
               file.type.startsWith('text/') ||
               file.type === 'application/json') &&
             dataURI.length < MAX_FILE_SIZE

--- a/packages/app/src/app/store/modules/files/actions.js
+++ b/packages/app/src/app/store/modules/files/actions.js
@@ -68,13 +68,14 @@ export async function uploadFiles({ api, props, path }) {
 
           if (
             (/\.(j|t)sx?$/.test(filePath) ||
+              /\.coffee$/.test(filePath) ||
               /\.json$/.test(filePath) ||
               /\.html$/.test(filePath) ||
               /\.vue$/.test(filePath) ||
               /\.styl$/.test(filePath) ||
-              /\.less$/.test(filePath) ||
-              /\.scss$/.test(filePath) ||
-              /\.sass$/.test(filePath) ||
+              /\.(le|sc|sa)ss$/.test(filePath) ||
+              /\.haml$/.test(filePath) ||
+              /\.pug$/.test(filePath) ||
               file.type.startsWith('text/') ||
               file.type === 'application/json') &&
             dataURI.length < MAX_FILE_SIZE


### PR DESCRIPTION
<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
Add (le|sa|sc)ss and style files types to the list of forced text extensions.


<!-- You can also link to an open issue here -->
**What is the current behavior?**
https://github.com/CompuIves/codesandbox-client/issues/348#issuecomment-416019773
When uploading(le|sa|sc)ss or styl (and probably other) files, and error message is thrown:

"This file is too big to edit
We will add support for this as soon as possible
Open file externally". 

It seems the zip implementation does not recognize them as text files. CompuIves recommends to add them to the list of forced text extensions.

Important: This happens only, when such files are *uploaded*! (creating such files within the editor works fine.)

<!-- if this is a feature change -->
**What is the new behavior?**
On upload, recognize more file types. (Again: on *upload*!)

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
I do this upon being challenged by compulves (see link above) to contribute.

<!-- Thank you for contributing! -->
