### PR TITLE
Dojo - Use existing .css.js file if it exists

### DIFF
--- a/packages/app/src/sandbox/eval/presets/dojo/transpilers/style.js
+++ b/packages/app/src/sandbox/eval/presets/dojo/transpilers/style.js
@@ -12,14 +12,17 @@ class DojoStyleTranspiler extends StyleTranspiler {
   async doTranspilation(code: string, loaderContext: LoaderContext) {
     const id = getStyleId(loaderContext._module.getId());
     const { path } = loaderContext;
-    const { code: packageJson } = loaderContext
-      .getModules()
-      .find(module => module.path === '/package.json');
+    const modules = loaderContext.getModules();
+    let result = modules.find(module => module.path === `${path}.js`);
+    if (result) {
+      return { transpiledCode: `${insertCss(id, code)}\n${result.code}` };
+    }
+    const { code: packageJson } = modules.find(module => module.path === '/package.json');
     const { name: packageName } = JSON.parse(packageJson);
     const [, baseName] = /\/([^/.]*)[^/]*$/.exec(path);
     const key = `${packageName}/${baseName}`;
     const { css, exportTokens } = await getModules(code, loaderContext);
-    let result = insertCss(id, css);
+    result = insertCss(id, css);
     result += `\nmodule.exports=${JSON.stringify({
       ' _key': key,
       ...exportTokens,


### PR DESCRIPTION
Use an existing generated CSS modules JS file if it exists.

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
Bug fix

<!-- You can also link to an open issue here -->
**What is the current behavior?**
Currently, the style loader for Dojo will automatically generate a CSS module JS file, even if one already exists, such as from the built packages in @dojo/widgets.

<!-- if this is a feature change -->
**What is the new behavior?**
The new behavior checks for the existence of a corresponding `.css.js` file and uses that instead of generating a new one.


<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation (N/A)
- [ ] Tests (N/A)
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
