### PR TITLE
Save downloaded JSON files to cache

### DIFF
--- a/packages/app/src/sandbox/eval/entities/module.js
+++ b/packages/app/src/sandbox/eval/entities/module.js
@@ -4,4 +4,5 @@ export type Module = {
   path: string,
   code: string,
   requires?: Array<string>,
+  downloaded?: boolean,
 };

--- a/packages/app/src/sandbox/eval/presets/angular-cli/index.js
+++ b/packages/app/src/sandbox/eval/presets/angular-cli/index.js
@@ -4,7 +4,6 @@ import Preset from '../';
 
 import angular2Transpiler from '../../transpilers/angular2-template';
 import typescriptTranspiler from '../../transpilers/typescript';
-import babelTranspiler from '../../transpilers/babel';
 import jsonTranspiler from '../../transpilers/json';
 import stylesTranspiler from '../../transpilers/style';
 import sassTranspiler from '../../transpilers/sass';
@@ -214,7 +213,7 @@ export default function initialize() {
   ]);
 
   preset.registerTranspiler(module => /\.js$/.test(module.path), [
-    { transpiler: babelTranspiler },
+    { transpiler: typescriptTranspiler },
   ]);
 
   preset.registerTranspiler(module => /\.json$/.test(module.path), [

--- a/packages/app/src/sandbox/eval/transpilers/babel/index.js
+++ b/packages/app/src/sandbox/eval/transpilers/babel/index.js
@@ -17,7 +17,7 @@ class BabelTranspiler extends WorkerTranspiler {
   worker: Worker;
 
   constructor() {
-    super('babel-loader', BabelWorker, 2, { hasFS: true });
+    super('babel-loader', BabelWorker, 3, { hasFS: true });
   }
 
   startupWorkersInitialized = false;

--- a/packages/app/src/sandbox/eval/transpilers/typescript/index.js
+++ b/packages/app/src/sandbox/eval/transpilers/typescript/index.js
@@ -8,7 +8,7 @@ class TypeScriptTranspiler extends WorkerTranspiler {
   worker: Worker;
 
   constructor() {
-    super('ts-loader', TypeScriptWorker, 2);
+    super('ts-loader', TypeScriptWorker, 3);
   }
 
   doTranspilation(code: string, loaderContext: LoaderContext) {

--- a/packages/app/src/sandbox/startup.js
+++ b/packages/app/src/sandbox/startup.js
@@ -1,6 +1,6 @@
 import BabelWorker from 'worker-loader?publicPath=/&name=babel-transpiler.[hash:8].worker.js!./eval/transpilers/babel/worker/index.js';
 
 window.babelworkers = [];
-for (let i = 0; i < 2; i++) {
+for (let i = 0; i < 3; i++) {
   window.babelworkers.push(new BabelWorker());
 }


### PR DESCRIPTION
Right now we don't download dynamically downloaded `package.json` files to cache, which causes errors when a sandbox is loaded from cache and a dependency uses a dynamic `package.json` to resolve another dynamically downloaded `js` file.

This fixes that by explicitly marking all dynamic `package.json` files as a dependency when they are used for resolving.

Fixes #1058