### PR TITLE
Make running tests conditional

### DIFF
--- a/packages/app/src/app/components/Preview/DevTools/Tests/index.js
+++ b/packages/app/src/app/components/Preview/DevTools/Tests/index.js
@@ -107,6 +107,10 @@ class Tests extends React.Component<Props, State> {
         running: true,
       });
     }
+
+    if (this.props.hidden && !nextProps.hidden) {
+      this.runAllTests();
+    }
   }
 
   selectFile = (file: File) => {
@@ -117,7 +121,9 @@ class Tests extends React.Component<Props, State> {
   };
 
   handleMessage = (data: Object) => {
-    if (data.type === 'test') {
+    if (data.type === 'done' && (!this.props.hidden || this.props.standalone)) {
+      this.runAllTests();
+    } else if (data.type === 'test') {
       switch (data.event) {
         case 'initialize_tests': {
           this.currentDescribeBlocks = [];

--- a/packages/app/src/app/components/Preview/DevTools/Tests/index.js
+++ b/packages/app/src/app/components/Preview/DevTools/Tests/index.js
@@ -133,6 +133,14 @@ class Tests extends React.Component<Props, State> {
           this.setState(INITIAL_STATE);
           break;
         }
+        case 'test_count': {
+          const { updateStatus } = this.props;
+          if (updateStatus) {
+            updateStatus('clear');
+            updateStatus('info', data.count);
+          }
+          break;
+        }
         case 'total_test_start': {
           this.currentDescribeBlocks = [];
           if (this.props.updateStatus) {

--- a/packages/app/src/sandbox/compile.js
+++ b/packages/app/src/sandbox/compile.js
@@ -554,23 +554,6 @@ async function compile({
       createCodeSandboxOverlay(modules);
     }
 
-    dispatch({ type: 'status', status: 'running-tests' });
-
-    try {
-      // Testing
-      const ttt = Date.now();
-      const testRunner = manager.testRunner;
-      testRunner.findTests(modules);
-      await testRunner.runTests();
-      debug(`Test Evaluation time: ${Date.now() - ttt}ms`);
-
-      // End - Testing
-    } catch (error) {
-      if (process.env.NODE_ENV === 'development') {
-        console.error(error);
-      }
-    }
-
     debug(`Total time: ${Date.now() - startTime}ms`);
 
     dispatch({

--- a/packages/app/src/sandbox/compile.js
+++ b/packages/app/src/sandbox/compile.js
@@ -26,7 +26,6 @@ import { consumeCache, saveCache, deleteAPICache } from './eval/cache';
 import getDefinition from '../../../common/templates/index';
 
 import { showRunOnClick } from './status-screen/run-on-click';
-import TestRunner from 'app/src/sandbox/eval/tests/jest-lite';
 
 let initializedResizeListener = false;
 let manager: ?Manager = null;

--- a/packages/app/src/sandbox/compile.js
+++ b/packages/app/src/sandbox/compile.js
@@ -26,6 +26,7 @@ import { consumeCache, saveCache, deleteAPICache } from './eval/cache';
 import getDefinition from '../../../common/templates/index';
 
 import { showRunOnClick } from './status-screen/run-on-click';
+import TestRunner from 'app/src/sandbox/eval/tests/jest-lite';
 
 let initializedResizeListener = false;
 let manager: ?Manager = null;
@@ -55,6 +56,17 @@ export function getHTMLParts(html: string) {
   }
 
   return { head: '', body: html };
+}
+
+function sendTestCount(manager: Manager, modules: Array<Module>) {
+  const testRunner = manager.testRunner;
+  const tests = testRunner.findTests(modules);
+
+  dispatch({
+    type: 'test',
+    event: 'test_count',
+    count: tests.length,
+  });
 }
 
 let firstLoad = true;
@@ -567,6 +579,16 @@ async function compile({
       changedModuleCount,
       firstLoad
     );
+
+    setTimeout(() => {
+      try {
+        sendTestCount(manager, modules);
+      } catch (e) {
+        if (process.env.NODE_ENV === 'development') {
+          console.error('Test error', e);
+        }
+      }
+    }, 600);
   } catch (e) {
     console.log('Error in sandbox:');
     console.error(e);

--- a/packages/app/src/sandbox/eval/tests/jest-lite.js
+++ b/packages/app/src/sandbox/eval/tests/jest-lite.js
@@ -143,6 +143,8 @@ export default class TestRunner {
     this.tests = Object.keys(modules)
       .filter(TestRunner.isTest)
       .map(p => modules[p]);
+
+    return this.tests;
   }
 
   /* istanbul ignore next */


### PR DESCRIPTION
Helps with #1075 and #1074.

All the Jest tests are currently executing in the same window as the main application, which can cause some trouble when tests alter the main DOM or do things like `location.reload`. The solution is to execute the tests in a separate iframe, but this will be quite some work before we can get there.

In the meantime I propose to only run the tests when the tests tab is opened, contrary to what we have now where we eagerly run tests as soon as the sandbox is evaluated. This will help with infinite loops cause by eg. `onSubmit` in a test and will not infer with the main evaluation of the sandbox.

There are some drawbacks:

- It will take a bit longer to load the tests when you open the Tests tab
- We will not show eagerly the green/red notification on the Tests tab if it's not opened

There also is the advantage that it should maybe give a small general perf boost since we don't evaluate tests after every run of a sandbox anymore if the tab is not opened.

I'm curious what @lbogdan and @kentcdodds think of this intermediate solution until we have separate iframe evaluation. Suggestions to a solution for the drawbacks are also welcome!