### PR TITLE
package.json: remove version field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "codesandbox",
-  "version": "0.1.0",
   "license": "MIT",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Hello, I'm huge fun of codesandbox and frequency using when I  thought little question, curiosity about React!

**What kind of change does this PR introduce?**
According to [npm docs](https://docs.npmjs.com/files/package.json#version),`package.json`'s `version` field necessary if you making npm module package.
Even though if you don't making npm module, this field is optional.
AFAIK this Project's shiping cycle does not related `package.json`'s `version`.

I think might be better to nobody cares unused version number, nitpick though.

Thanks😀