### PR TITLE
[docs] importing - template can be specified in sandbox.config.json

### DIFF
--- a/packages/homepage/content/docs/2-importing.md
+++ b/packages/homepage/content/docs/2-importing.md
@@ -33,6 +33,14 @@ We infer sandbox settings based on several files in a repository.
 | Template - React-Typescript | If `package.json` dependencies contains `react-scripts-ts`. |
 | Template - Svelte           | If `package.json` dependencies contains `svelte`.           |
 
+Additionally, you may specify a `template` property in your `./sandbox.config.json` file.
+
+```json
+{
+  "template": "node"
+}
+```
+
 ### Source
 
 You can find the source of our git extractor [here](https://github.com/codesandbox-app/git-extractor).

--- a/packages/homepage/content/docs/3-configuration.md
+++ b/packages/homepage/content/docs/3-configuration.md
@@ -25,3 +25,4 @@ A sandbox can be configured too, you can do this with `sandbox.config.json`. We 
 | `infiniteLoopProtection` | Whether we should throw an error if we detect an infinite loop                                    | `true`/`false`              | `true`        |
 | `hardReloadOnChange`     | Whether we should refresh the sandbox page on every change, good for sandboxes with global state. | `true`/`false`              | `false`       |
 | `view`                   | Which view to show by default as the preview when opening the sandbox.                            | `browser`/`console`/`tests` | `browser`     |
+| `template`               | Which sandbox template to use                                                                     | [see here](https://github.com/codesandbox-app/codesandbox-importers/blob/master/packages/types/index.d.ts#L24-L39) | smart detection, w/ fallback to `create-react-app` |


### PR DESCRIPTION
Documentation describing the ability to specify a `template` in `sandbox.config.json`