### PR TITLE
Add *.css to sideEffects

### DIFF
--- a/packages/react-sandpack/package.json
+++ b/packages/react-sandpack/package.json
@@ -12,7 +12,7 @@
     "dist",
     "es"
   ],
-  "sideEffects": false,
+  "sideEffects": "*.css",
   "author": "Ives van Hoorne <ives.v.h@gmail.com>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi! I started using react-sandpack with Webpack 4 (CRA v2) and loading `react-smooshpack/dist/styles.css` is broken in production mode. The problem seems to be the sideEffects in package.json.
More info:
- https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free
- https://github.com/facebook/create-react-app/issues/5140