### PR TITLE
fix(github): Resetting error state when changing the repo title

### DIFF
--- a/packages/app/src/app/store/modules/git/sequences.js
+++ b/packages/app/src/app/store/modules/git/sequences.js
@@ -2,7 +2,10 @@ import { set, when, wait } from 'cerebral/operators';
 import { state, props, string } from 'cerebral/tags';
 import * as actions from './actions';
 
-export const changeRepoTitle = set(state`git.repoTitle`, props`title`);
+export const changeRepoTitle = [
+  set(state`git.repoTitle`, props`title`),
+  set(state`git.error`, null),
+];
 
 export const changeSubject = set(state`git.subject`, props`subject`);
 


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
Bug fix. Closes #1131.

<!-- You can also link to an open issue here -->
**What is the current behavior?**
When the "Create Repository" button is clicked, the input's value is validated and when there is an error, it's saved in the `git.error` state. But when the user changes the input's value (maybe solving the previous error), the button doesn't become enabled again.
<!-- if this is a feature change -->
**What is the new behavior?**
When the user changes the input's value, the `git.error` state is set to `null`, so the button become enabled again.

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
 