### PR TITLE
fix(patron): Fixing crash on slider

### DIFF
--- a/packages/app/src/app/pages/Patron/PricingModal/Badge/Particles/index.js
+++ b/packages/app/src/app/pages/Patron/PricingModal/Badge/Particles/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { forEach } from 'lodash-es';
 
 import badges from 'common/utils/badges/patron-info';
 import { Particle } from './elements';
@@ -37,10 +38,10 @@ const createParticles = (amount: number, badge) =>
 export default class Particles extends React.Component {
   makeItRain = () => {
     const particleSelector = document.getElementsByClassName('particle');
-    Array.forEach(particleSelector, hideElement);
+    forEach(particleSelector, hideElement);
 
     requestAnimationFrame(() => {
-      Array.forEach(particleSelector, showElement);
+      forEach(particleSelector, showElement);
     });
   };
 
@@ -52,10 +53,10 @@ export default class Particles extends React.Component {
         `${nextProps.badge}-particle`
       );
 
-      Array.forEach(particleSelector, hideElement);
+      forEach(particleSelector, hideElement);
 
       requestAnimationFrame(() => {
-        Array.forEach(particleSelector, showElement);
+        forEach(particleSelector, showElement);
       });
 
       if (this.timeout) {
@@ -64,7 +65,7 @@ export default class Particles extends React.Component {
 
       this.timeout = setTimeout(() => {
         const allParticleSelector = document.getElementsByClassName('particle');
-        Array.forEach(allParticleSelector, hideElement);
+        forEach(allParticleSelector, hideElement);
       }, 700);
     }
 


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
Bug fix. Closes #1138.
<!-- You can also link to an open issue here -->
**What is the current behavior?**
The app breaks on Chrome when the slider goes over $14 (and the badge would change) because `Array.forEach` is `undefined` (I had no idea about this).
<!-- if this is a feature change -->
**What is the new behavior?**
Using lodash-es' `forEach, the app doesn't break.

<!-- feel free to add additional comments -->
 An alternative would be using `Array.from().forEach`, but lodash-es' `forEach` syntax is simpler, in my opinion. Let me know if you prefer the native method.
<!-- Thank you for contributing! -->
