### PR TITLE
fix(trash): Updating list of deleted sandboxes after permanent removal

### DIFF
--- a/packages/app/src/app/pages/Dashboard/queries.js
+++ b/packages/app/src/app/pages/Dashboard/queries.js
@@ -263,13 +263,19 @@ export function permanentlyDeleteSandboxes(selectedSandboxes) {
           query: DELETED_SANDBOXES_CONTENT_QUERY,
         });
 
-        oldDeleteCache.me.sandboxes = oldDeleteCache.me.sandboxes.filter(
-          x => selectedSandboxes.indexOf(x.id) === -1
-        );
+        const newDeleteCache = {
+          ...oldDeleteCache,
+          me: {
+            ...oldDeleteCache.me,
+            sandboxes: oldDeleteCache.me.sandboxes.filter(
+              x => selectedSandboxes.indexOf(x.id) === -1
+            ),
+          },
+        };
 
         cache.writeQuery({
           query: DELETED_SANDBOXES_CONTENT_QUERY,
-          data: oldDeleteCache,
+          data: newDeleteCache,
         });
       } catch (e) {
         // cache doesn't exist, no biggie!


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
Bug fix.
<!-- You can also link to an open issue here -->
**What is the current behavior?**
After permanently deleting sandboxes, the grid is not updated because the `oldDeleteCache` is mutated when updating the cache.
<!-- if this is a feature change -->
**What is the new behavior?**
Creating a `newDeleteCache` with all the previous data and overriding `me.sandboxes`, the grid is updated as expected.


<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
