### PR TITLE
Remove ternary in favor of short &&

### DIFF
--- a/packages/app/src/app/pages/Sandbox/SearchDependencies/DependencyHit/index.js
+++ b/packages/app/src/app/pages/Sandbox/SearchDependencies/DependencyHit/index.js
@@ -132,7 +132,7 @@ export default class DependencyHit extends React.PureComponent {
                 const tagName = getTagName(hit.tags, v);
                 return (
                   <option key={v}>
-                    {v} {tagName ? `- ${tagName}` : ''}
+                    {v} {tagName && `- ${tagName}`}
                   </option>
                 );
               })}


### PR DESCRIPTION
Really small but this was bugging me from my previous PR (#1110) - don't have an else so ternary is unnecessary :)

**What kind of change does this PR introduce?**

Use logical `&&` instead.

**What is the current behavior?**

Ternary.