### PR TITLE
fix(profile): Update sandboxes count after delete

### DIFF
--- a/packages/app/src/app/pages/Profile/Sandboxes/index.js
+++ b/packages/app/src/app/pages/Profile/Sandboxes/index.js
@@ -58,8 +58,8 @@ class Sandboxes extends React.Component {
     return Math.ceil(givenLikeCount / PER_PAGE_COUNT);
   };
 
-  deleteSandbox = index => {
-    this.props.signals.profile.deleteSandboxClicked({ index });
+  deleteSandbox = id => {
+    this.props.signals.profile.deleteSandboxClicked({ id });
   };
 
   render() {
@@ -82,8 +82,12 @@ class Sandboxes extends React.Component {
       <div>
         {isProfileCurrentUser && (
           <Notice>
-            You{"'"}re viewing your own profile, so you can see your private and
-            unlisted sandboxes. Others can{"'"}t.
+            You
+            {"'"}
+            re viewing your own profile, so you can see your private and
+            unlisted sandboxes. Others can
+            {"'"}
+            t.
           </Notice>
         )}
         <SandboxList

--- a/packages/app/src/app/store/modules/profile/actions.js
+++ b/packages/app/src/app/store/modules/profile/actions.js
@@ -4,6 +4,7 @@ export function getUser({ api, props }) {
 
 export function deleteSandbox({ api, state }) {
   const sandboxId = state.get(`profile.sandboxToDeleteId`);
+  const sandboxCount = state.get('profile.current.sandboxCount');
 
   return api
     .request({
@@ -13,7 +14,9 @@ export function deleteSandbox({ api, state }) {
         id: sandboxId,
       },
     })
-    .then(() => state.set(`profile.current.sandboxCount - 1`));
+    .then(() => {
+      state.set(`profile.current.sandboxCount`, sandboxCount - 1);
+    });
 }
 
 export function getAllUserSandboxes({ api }) {

--- a/packages/app/src/app/store/modules/profile/sequences.js
+++ b/packages/app/src/app/store/modules/profile/sequences.js
@@ -22,7 +22,7 @@ const getShowcasedSandbox = sequence('getShowcasedSandbox', [
 ]);
 
 export const showDeleteSandboxModal = [
-  set(state`profile.sandboxToDeleteId`, props`index`),
+  set(state`profile.sandboxToDeleteId`, props`id`),
   set(state`currentModal`, 'deleteProfileSandbox'),
 ];
 


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
Bug fix.
<!-- You can also link to an open issue here -->
**What is the current behavior?**
If you are on your profile and delete a sandbox, the sandboxes count is not updated.
<!-- if this is a feature change -->
**What is the new behavior?**
The count is updated if the delete operation is successful.


<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
