### PR TITLE
Add minimum value to the PriceInput

### DIFF
--- a/packages/app/src/app/pages/Patron/PricingModal/PricingChoice/index.js
+++ b/packages/app/src/app/pages/Patron/PricingModal/PricingChoice/index.js
@@ -39,6 +39,7 @@ function PricingChoice({ store, signals, badge }) {
               signals.patron.priceChanged({ price: Number(event.target.value) })
             }
             value={store.patron.price}
+            min={5}
             type="number"
           />
           <Month>/month</Month>


### PR DESCRIPTION
Presently, users can enter invalid values, such as -10, by using the native browser controls associated with inputs with a type of "number".

This prevents the following situation:

![image](https://user-images.githubusercontent.com/2322305/47125004-e745a180-d235-11e8-98d3-038c7c708b6f.png)

I went with 5 as the minimum due to the validation that's in place that requires that as the minimum:

![image](https://user-images.githubusercontent.com/2322305/47125022-f9274480-d235-11e8-89fa-d52bf4c6905d.png)

(p.s. that credit card info is fake)

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**

It's a small update to the Patron page.

<!-- You can also link to an open issue here -->
**What is the current behavior?**

Users are able to enter values less than 5 (and also less than 0) into the input.

<!-- if this is a feature change -->
**What is the new behavior?**

Users are unable to enter numbers less than 5 into the input.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions --> N/A

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
