### PR TITLE
Pushing wipes "future" history

### DIFF
--- a/packages/app/src/app/components/Preview/index.js
+++ b/packages/app/src/app/components/Preview/index.js
@@ -567,7 +567,6 @@ class BasePreview extends React.Component<Props, State> {
 
   commitUrl = (url: string, action: string, diff: number) => {
     const { history, historyPosition } = this.state;
-
     switch (action) {
       case 'POP':
         this.setState(prevState => {
@@ -590,7 +589,7 @@ class BasePreview extends React.Component<Props, State> {
         break;
       default:
         this.setState({
-          history: [...history, url],
+          history: [...history.slice(0, historyPosition + 1), url],
           historyPosition: historyPosition + 1,
           urlInAddressBar: url,
         });

--- a/packages/app/src/app/components/Preview/index.js
+++ b/packages/app/src/app/components/Preview/index.js
@@ -567,6 +567,7 @@ class BasePreview extends React.Component<Props, State> {
 
   commitUrl = (url: string, action: string, diff: number) => {
     const { history, historyPosition } = this.state;
+
     switch (action) {
       case 'POP':
         this.setState(prevState => {

--- a/packages/sandbox-hooks/url-listeners.js
+++ b/packages/sandbox-hooks/url-listeners.js
@@ -17,9 +17,10 @@ let historyPosition = -1;
 let disableNextHashChange = false;
 
 function pushHistory(url, state) {
-  historyPosition += 1;
-  historyList.length = historyPosition + 1;
-  historyList[historyPosition] = { url, state };
+  // remove "future" locations
+  historyList.splice(historyPosition + 1);
+  historyList.push({ url, state });
+  historyPosition = historyList.length - 1;
 }
 
 function pathWithHash(location) {


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**

Follow up to #1158. I noticed that pushing locations when there is "future" history doesn't work correctly (the "forward" button is still active after pushing).

<!-- You can also link to an open issue here -->
**What is the current behavior?**

Pushing adds the new location to the end of the history array. This bug is hidden because the `<Preview>` keeps a `urlInAddressBar` property in state.

`history[historyPosition]` _should_ be usable everywhere that `urlInAddressBar` is. I can take a look at whether that works in another PR, but I'd rather get this fix merged in first.

<!-- if this is a feature change -->
**What is the new behavior?**

Pushing a new location adds it after the current location, wiping out any "future" locations.

I also updated the `historyList` array kept in `url-listeners` to drop "future" locations when pushing so that `historyList.length` doesn't have to be manually set.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
