### PR TITLE
Fix support for TSX in Dojo template

### DIFF
--- a/packages/common/templates/configuration/tsconfig/index.js
+++ b/packages/common/templates/configuration/tsconfig/index.js
@@ -117,6 +117,37 @@ const config: ConfigurationFile = {
       );
     }
 
+    if (template === '@dojo/cli-create-app') {
+      return JSON.stringify(
+        {
+          compilerOptions: {
+            declaration: false,
+            experimentalDecorators: true,
+            jsx: 'react',
+            jsxFactory: 'tsx',
+            lib: [
+              'dom',
+              'es5',
+              'es2015.promise',
+              'es2015.iterable',
+              'es2015.symbol',
+              'es2015.symbol.wellknown'
+            ],
+            module: 'commonjs',
+            moduleResolution: 'node',
+            noUnusedLocals: true,
+            outDir: '_build/',
+            removeComments: false,
+            importHelpers: true,
+            downLevelIteration: true,
+            sourceMap: true,
+            strict: true,
+            target: 'es5'
+          }
+        }
+      );
+    }
+
     return JSON.stringify(
       {
         compilerOptions: {

--- a/packages/common/templates/dojo.js
+++ b/packages/common/templates/dojo.js
@@ -2,6 +2,7 @@
 
 import Template from './template';
 import { decorateSelector } from '../theme';
+import configurations from './configuration';
 
 export class DojoTemplate extends Template {
   // eslint-disable-next-line no-unused-vars
@@ -28,5 +29,8 @@ export default new DojoTemplate(
     showOnHomePage: true,
     showCube: false,
     isTypescript: true,
+    extraConfigurations: {
+      '/tsconfig.json': configurations.tsconfig
+    },
   }
 );


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**

This fixes #1258 - issues with Dojo codesandboxes where TSX ends up using the wrong pragma via the following changes:

- Add /tsconfig.json as a configuration to the Dojo template
- Add a default tsconfig option for Dojo template

<!-- You can also link to an open issue here -->
**What is the current behavior?**

Current Dojo templates fail by trying to use `react.createElement`

<!-- if this is a feature change -->
**What is the new behavior?**

This fixes Dojo templates to instead use the `tsx` pragma. 

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

I didn't see any tests for this portion of the code, but I am happy to add tests if I missed them!

<!-- Thank you for contributing! -->