### PR TITLE
Redirect to sandbox wizard when deleting sandbox

### DIFF
--- a/packages/app/src/app/store/modules/workspace/actions.js
+++ b/packages/app/src/app/store/modules/workspace/actions.js
@@ -27,6 +27,10 @@ export function redirectToNewSandbox({ router }) {
   router.redirectToNewSandbox();
 }
 
+export function redirectToSandboxWizard({ router }) {
+  router.redirectToSandboxWizard();
+}
+
 export function updateSandbox({ api, state }) {
   const sandboxId = state.get('editor.currentId');
   const body = {

--- a/packages/app/src/app/store/modules/workspace/sequences.js
+++ b/packages/app/src/app/store/modules/workspace/sequences.js
@@ -39,9 +39,7 @@ export const deleteSandbox = [
   actions.deleteSandbox,
   set(state`workspace.showDeleteSandboxModal`, false),
   addNotification('Sandbox deleted!', 'success'),
-  actions.redirectToNewSandbox,
-  set(props`id`, 'new'),
-  loadSandbox,
+  actions.redirectToSandboxWizard,
 ];
 
 export const openIntegrations = [

--- a/packages/app/src/app/store/providers/Router.js
+++ b/packages/app/src/app/store/providers/Router.js
@@ -10,6 +10,9 @@ export default Provider({
   redirectToNewSandbox() {
     history.push('/s/new');
   },
+  redirectToSandboxWizard() {
+    history.push('/s');
+  },
   getSandboxOptions() {
     return getSandboxOptions(decodeURIComponent(document.location.href));
   },

--- a/packages/app/src/app/store/providers/Router.js
+++ b/packages/app/src/app/store/providers/Router.js
@@ -11,7 +11,7 @@ export default Provider({
     history.push('/s/new');
   },
   redirectToSandboxWizard() {
-    history.push('/s');
+    history.replace('/s');
   },
   getSandboxOptions() {
     return getSandboxOptions(decodeURIComponent(document.location.href));

--- a/packages/app/src/app/store/providers/Router.js
+++ b/packages/app/src/app/store/providers/Router.js
@@ -11,7 +11,7 @@ export default Provider({
     history.push('/s/new');
   },
   redirectToSandboxWizard() {
-    history.replace('/s');
+    history.replace('/s/');
   },
   getSandboxOptions() {
     return getSandboxOptions(decodeURIComponent(document.location.href));


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**

This PR changes where the user is redirected after deleting a sandbox.

Fixes #1312 

<!-- You can also link to an open issue here -->
**What is the current behavior?**

The user is redirected to the new React template (`/s/new`).

<!-- if this is a feature change -->
**What is the new behavior?**

The user is redirected to the sandbox wizard (`/s`).

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
