### PR TITLE
Add zeit 2 support

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/index.js
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/Deployment/index.js
@@ -24,7 +24,6 @@ import {
 class Deployment extends Component {
   componentDidMount = () => {
     this.props.signals.deployment.getDeploys();
-    this.props.signals.deployment.getPeople();
   };
 
   render() {
@@ -33,9 +32,6 @@ class Deployment extends Component {
       store: { user, deployment },
     } = this.props;
 
-    const hasVoted = deployment.peopleWant2.find(
-      a => a.username === user.username
-    );
     return (
       <div>
         <Description>
@@ -49,50 +45,6 @@ class Deployment extends Component {
           </a>.
           {!user.integrations.zeit &&
             ' You need to add ZEIT to your integrations to deploy.'}
-        </Description>
-        <Description
-          css={`
-            margin: 0;
-            padding: 0.5rem 1rem;
-
-            background: #122d42;
-          `}
-        >
-          We currently only support Zeit v1.
-          {!hasVoted && deployment.peopleWant2.length ? (
-            <Fragment>
-              <br />
-              <br />
-              If you would like us to support version 2.0 too please add your
-              thumbs up
-            </Fragment>
-          ) : null}
-          <Button
-            css={`
-              padding: 5px 8px;
-              margin-top: 1rem;
-            `}
-            block
-            disabled={hasVoted || !deployment.peopleWant2.length}
-            onClick={() =>
-              signals.deployment.addPersonFor2({
-                username: user.username,
-              })
-            }
-          >
-            {deployment.peopleWant2.length > 0
-              ? `${deployment.peopleWant2.length} people want v2`
-              : null}{' '}
-            <span
-              css={`
-                margin-left: 5px;
-              `}
-              role="img"
-              aria-label="I want this"
-            >
-              👍
-            </span>
-          </Button>
         </Description>
 
         {user.integrations.zeit ? (

--- a/packages/app/src/app/store/modules/deployment/index.js
+++ b/packages/app/src/app/store/modules/deployment/index.js
@@ -5,7 +5,6 @@ import * as sequences from './sequences';
 export default Module({
   model,
   state: {
-    peopleWant2: [],
     hasAlias: false,
     deployToDelete: null,
     deploying: false,
@@ -15,12 +14,10 @@ export default Module({
   },
   signals: {
     getDeploys: sequences.getDeploys,
-    addPersonFor2: sequences.addPersonFor2,
     deployClicked: sequences.deploy,
     deploySandboxClicked: sequences.openDeployModal,
     setDeploymentToDelete: sequences.deploymentToDelete,
     deleteDeployment: sequences.deleteDeployment,
     aliasDeployment: sequences.aliasDeployment,
-    getPeople: sequences.getPeopleWhoWant2,
   },
 });

--- a/packages/app/src/app/store/modules/deployment/model.js
+++ b/packages/app/src/app/store/modules/deployment/model.js
@@ -36,15 +36,10 @@ const Deploy = types.model('Deploy', {
   alias: types.maybeNull(types.array(Alias)),
   scale: types.maybeNull(Scale),
   creator: Creator,
-  type: types.enumeration('types', ['NPM', 'DOCKER', 'STATIC']),
-});
-
-const People = types.model('Person', {
-  username: types.maybeNull(types.string),
+  type: types.enumeration('types', ['NPM', 'DOCKER', 'STATIC', 'LAMBDAS']),
 });
 
 export default {
-  peopleWant2: types.array(People),
   hasAlias: types.boolean,
   deployToDelete: types.maybeNull(types.string),
   deploying: types.boolean,

--- a/packages/app/src/app/store/modules/deployment/sequences.js
+++ b/packages/app/src/app/store/modules/deployment/sequences.js
@@ -14,30 +14,6 @@ export const deploymentToDelete = [
   set(state`deployment.deployToDelete`, props`id`),
 ];
 
-export const getPeopleWhoWant2 = [
-  actions.getPeopleWhoWant2,
-  set(state`deployment.peopleWant2`, props`people`),
-];
-
-export const addPersonFor2 = [
-  actions.addPersonWhoWant2,
-  {
-    success: [
-      actions.getPeopleWhoWant2,
-      set(state`deployment.peopleWant2`, props`people`),
-      addNotification('Your feedback has been saved', 'success'),
-    ],
-    error: [
-      addNotification(
-        'An unknown error occurred when adding your vote',
-        'error'
-      ),
-    ],
-  },
-  actions.getPeopleWhoWant2,
-  set(state`deployment.peopleWant2`, props`people`),
-];
-
 export const getDeploys = [
   actions.getDeploymentData,
   actions.getDeploymentData,

--- a/packages/common/templates/configuration/now/index.js
+++ b/packages/common/templates/configuration/now/index.js
@@ -7,14 +7,7 @@ const config: ConfigurationFile = {
   description: 'Configuration for your deployments on now.',
   moreInfoUrl: 'https://zeit.co/docs/features/configuration',
 
-  getDefaultCode: () =>
-    JSON.stringify(
-      {
-        type: 'NPM',
-      },
-      null,
-      2
-    ),
+  getDefaultCode: () => JSON.stringify({}, null, 2),
 };
 
 export default config;

--- a/packages/common/templates/template.js
+++ b/packages/common/templates/template.js
@@ -126,8 +126,8 @@ export default class Template {
         serve: '^10.1.1',
       },
       scripts: {
-        ...parsedFile.scripts,
         'now-start': `cd ${this.distDir} && serve -s ./`,
+        ...parsedFile.scripts,
       },
     };
 


### PR DESCRIPTION
<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
Adds support for zeit now version 2

<!-- You can also link to an open issue here -->
**What is the current behavior?**
Currently we have a counter and it had like 140 people so I guess it's time

<!-- if this is a feature change -->
**What is the new behavior?**
If the now.json has `version:2` specified the new now platform will be used

Here is an example: 
https://codesandbox-v2-test.now.sh/graphql

Also all the other endpoints remained the same so it was easier then I thought o.o

cc @timothyis @rauchg
