### PR TITLE
add private gh to patron features

### DIFF
--- a/packages/app/src/app/pages/Patron/PricingModal/PricingInfo/index.js
+++ b/packages/app/src/app/pages/Patron/PricingModal/PricingInfo/index.js
@@ -30,6 +30,11 @@ function PricingInfo() {
             free="20Mb"
             supporter="500Mb"
           />
+          <Feature
+            feature="GitHub Private Repositories"
+            free="No"
+            supporter="Yes"
+          />
         </tbody>
       </table>
     </Container>

--- a/packages/app/src/app/pages/Patron/PricingModal/PricingInfo/index.js
+++ b/packages/app/src/app/pages/Patron/PricingModal/PricingInfo/index.js
@@ -25,6 +25,7 @@ function PricingInfo() {
           />
           <Feature feature="Private Sandboxes" free="No" supporter="Yes" />
           <Feature feature="Sandbox Limit" free="50" supporter="Unlimited" />
+          <Feature feature="Server Sandbox Limit" free="5" supporter="20" />
           <Feature
             feature="Static File Hosting"
             free="20Mb"


### PR DESCRIPTION
<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
Docs update.

<!-- You can also link to an open issue here -->
**What is the current behavior?**

<!-- if this is a feature change -->
**What is the new behavior?**
Adds the fact that private github import is from patrons only

<img width="1552" alt="screenshot 2019-01-01 at 22 59 18" src="https://user-images.githubusercontent.com/1051509/50577139-1624ea00-0e19-11e9-91c9-a16b2592616c.png">

