### PR TITLE
add .mjs extension to utils/get-type

### DIFF
--- a/packages/app/src/app/utils/get-type.js
+++ b/packages/app/src/app/utils/get-type.js
@@ -22,7 +22,7 @@ const regexCasesMap = {
   react: /\.jsx$/,
   reason: /\.re$/,
   sass: /\.scss$/,
-  javascript: /\.js$/,
+  javascript: /\.m?js$/,
   typescript: /\.tsx?$/,
   console: /\.sh$/,
   // STARTS WITH


### PR DESCRIPTION
Is it a "feature"

Just add highlight for .mjs files.

- [V ] Documentation
- [ X] Tests
- [ V] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ X] Added myself to contributors table
