### PR TITLE
Use tsconfig setting for jsxFactory and reactNamespace in editor(s)

### DIFF
--- a/packages/app/src/app/components/CodeEditor/Monaco/index.js
+++ b/packages/app/src/app/components/CodeEditor/Monaco/index.js
@@ -332,8 +332,8 @@ class MonacoEditor extends React.Component<Props, State> implements Editor {
     const reactNamespace = existingConfig.reactNamespace || 'React';
 
     const compilerDefaults = {
-      jsxFactory: jsxFactory,
-      reactNamespace: reactNamespace,
+      jsxFactory,
+      reactNamespace,
       jsx: this.monaco.languages.typescript.JsxEmit.React,
       target: this.monaco.languages.typescript.ScriptTarget.ES2016,
       allowNonTsExtensions: !hasNativeTypescript,

--- a/packages/app/src/app/components/CodeEditor/Monaco/index.js
+++ b/packages/app/src/app/components/CodeEditor/Monaco/index.js
@@ -328,10 +328,12 @@ class MonacoEditor extends React.Component<Props, State> implements Editor {
   setCompilerOptions = () => {
     const hasNativeTypescript = this.hasNativeTypescript();
     const existingConfig = this.tsconfig ? this.tsconfig.compilerOptions : {};
+    const jsxFactory = existingConfig.jsxFactory || 'React.createElement';
+    const reactNamespace = existingConfig.reactNamespace || 'React';
 
     const compilerDefaults = {
-      jsxFactory: 'React.createElement',
-      reactNamespace: 'React',
+      jsxFactory: jsxFactory,
+      reactNamespace: reactNamespace,
       jsx: this.monaco.languages.typescript.JsxEmit.React,
       target: this.monaco.languages.typescript.ScriptTarget.ES2016,
       allowNonTsExtensions: !hasNativeTypescript,

--- a/packages/app/src/app/components/CodeEditor/VSCode/index.js
+++ b/packages/app/src/app/components/CodeEditor/VSCode/index.js
@@ -422,8 +422,8 @@ class MonacoEditor extends React.Component<Props, State> implements Editor {
     const reactNamespace = existingConfig.reactNamespace || 'React';
 
     const compilerDefaults = {
-      jsxFactory: jsxFactory,
-      reactNamespace: reactNamespace,
+      jsxFactory,
+      reactNamespace,
       jsx: this.monaco.languages.typescript.JsxEmit.React,
       target: this.monaco.languages.typescript.ScriptTarget.ES2016,
       allowNonTsExtensions: !hasNativeTypescript,

--- a/packages/app/src/app/components/CodeEditor/VSCode/index.js
+++ b/packages/app/src/app/components/CodeEditor/VSCode/index.js
@@ -418,10 +418,12 @@ class MonacoEditor extends React.Component<Props, State> implements Editor {
   setCompilerOptions = () => {
     const hasNativeTypescript = this.hasNativeTypescript();
     const existingConfig = this.tsconfig ? this.tsconfig.compilerOptions : {};
+    const jsxFactory = existingConfig.jsxFactory || 'React.createElement';
+    const reactNamespace = existingConfig.reactNamespace || 'React';
 
     const compilerDefaults = {
-      jsxFactory: 'React.createElement',
-      reactNamespace: 'React',
+      jsxFactory: jsxFactory,
+      reactNamespace: reactNamespace,
       jsx: this.monaco.languages.typescript.JsxEmit.React,
       target: this.monaco.languages.typescript.ScriptTarget.ES2016,
       allowNonTsExtensions: !hasNativeTypescript,


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixes https://github.com/CompuIves/codesandbox-client/issues/1487

**What is the current behavior?**
Does not use tsconfig compilerOptions for `jsxFactory` or `reactNamespace` which results in editor errors.

**What is the new behavior?**
Uses tsconfig compilerOptions for `jsxFactory` or `reactNamespace`.

**Checklist**:
- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged
- [ ] Added myself to contributors table

I don't think any Documentation needs to be updated as I believe this is desired behaviour (the correct options are passed to the actual ts transpiler). I tested the changes locally with the sandbox linked in the original bug report.