### PR TITLE
fix typo, 'verical-align'  should be ' vertical-align'

### DIFF
--- a/packages/app/src/app/pages/common/Notifications/Notification/elements.js
+++ b/packages/app/src/app/pages/common/Notifications/Notification/elements.js
@@ -27,7 +27,7 @@ export const Content = styled.div`
   align-items: center;
   padding: 0 1rem;
   height: 100%;
-  verical-align: middle;
+  vertical-align: middle;
   line-height: 1.15;
   box-sizing: border-box;
   color: ${() => theme.white()};


### PR DESCRIPTION
What kind of change does this PR introduce?

Fix a typo

What is the current behavior?

The word is spelled "verical-align"

What is the new behavior?

The word has been changed to "vertical-align"

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
