### PR TITLE
add search analytics tag to dependencies search

### DIFF
--- a/packages/app/src/app/pages/Sandbox/SearchDependencies/index.js
+++ b/packages/app/src/app/pages/Sandbox/SearchDependencies/index.js
@@ -53,7 +53,10 @@ export default class SearchDependencies extends React.PureComponent {
         apiKey="00383ecd8441ead30b1b0ff981c426f5"
         indexName="npm-search"
       >
-        <Configure hitsPerPage={5} />
+        <Configure
+          analyticsTags={['codesandbox-dependencies']}
+          hitsPerPage={5}
+        />
         <ConnectedAutoComplete
           onSelect={this.handleSelect}
           onManualSelect={this.handleManualSelect}


### PR DESCRIPTION
This is to make sure we can correctly know how many of the queries are from codesandbox, and which kind of empty queries are done

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**

Adds tags to the dependency search

<!-- You can also link to an open issue here -->
**What is the current behavior?**

no specific tags are sent

<!-- if this is a feature change -->
**What is the new behavior?**

a tag "codesandbox-dependencies" is sent when people search for dependencies


<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation N/A
- [x] Tests N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->