### PR TITLE
Do not silently ignore package.json in zeit deployment

### DIFF
--- a/packages/app/src/app/store/modules/deployment/actions.js
+++ b/packages/app/src/app/store/modules/deployment/actions.js
@@ -88,6 +88,12 @@ export async function createApiData({ props, state }) {
 
       apiData.files.push({ file: filePath, data, encoding: 'base64' });
     }
+    if (filePath === 'package.json') {
+      apiData.files.push({
+        file: 'package.json',
+        data: JSON.stringify(packageJSON, null, 2),
+      });
+    }
   }
 
   // this adds unnecessary code for version 2


### PR DESCRIPTION
<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
Fix
<!-- You can also link to an open issue here -->
**What is the current behavior?**

If you omit the `files` entry in your `now.json` then the deployment works without any issues but if you customize the `now.files` and you happen to have `package.json` in that list, it will be ignored from the deployment. If the package.json is omitted then zeit won't install the required dependencies.

Example configuration:

now.json
```
{
  "version": 2,
  "files": [
      "index.js",
      "package.json"
   ],
   "builds": [{
      "src": "index.js",
      "use": "@now/node"
    }]
}
```

package.json
```
{
  "dependencies": {
       "express": "4.16.4"
   }
}
```

index.js
```
require('express');
```

The deployment of a sandbox with the configuration above will be successful but when you are trying to open your deployment it'll crash with an error of 500. (`MODULE_NOT_FOUND`)

<!-- if this is a feature change -->
**What is the new behavior?**

If the user add `package.json` to the `now.files` it'll be included.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests - need help here
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table (see #1542) <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->


I found this issue while I was building a Pusher authentication server using zeit for a [sample vue chat app](https://codesandbox.io/s/9z1prn05pr).  I had to define the `now.files` since the sandbox has lots of files (config, static, build, etc) which should be deployed to zeit (and cannot be due to some zeit errors). For now, I moved the server to a different sandbox and deployed from [there](https://codesandbox.io/s/j4v80y7wzw).

<!-- Thank you for contributing! -->
