### PR TITLE
Make CodeSandbox logo icon clickable again

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Header/elements.js
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/elements.js
@@ -35,7 +35,6 @@ export const Left = styled.div`
 `;
 
 export const Centered = styled.div`
-  position: absolute;
   right: 0;
   left: 0;
   display: flex;


### PR DESCRIPTION
## Bug Fix
### Steps to reproduce
- Create a new sandbox
- Give it a name (preferably something long)
- Try to click the codesanbox logo in the left top corner
### New Changes
The navigation container's centered style overrides the position of the logo's <a> element.
Removing `position: absolute` makes it clickable again. The title of the sandbox is not positioned the same way as before though.
