### PR TITLE
fix: Syntax error in IE11

### DIFF
--- a/packages/app/src/app/index.html
+++ b/packages/app/src/app/index.html
@@ -59,9 +59,11 @@
           env: {
             VSCODE_DEV: false
           },
-          nextTick: (cb) => requestAnimationFrame(cb),
+          nextTick: function(cb) {
+            return requestAnimationFrame(cb);
+          },
           once: BrowserFS.BFSRequire('process').once,
-          removeListener: () => {}
+          removeListener: function () {}
         };
         window.Buffer = BrowserFS.BFSRequire('buffer').Buffer;
       }

--- a/packages/app/src/embed/index.html
+++ b/packages/app/src/embed/index.html
@@ -48,9 +48,11 @@
           env: {
             VSCODE_DEV: false
           },
-          nextTick: (cb) => requestAnimationFrame(cb),
+          nextTick: function(cb) {
+            return requestAnimationFrame(cb);
+          },
           once: BrowserFS.BFSRequire('process').once,
-          removeListener: () => {}
+          removeListener: function () {}
         };
         window.Buffer = BrowserFS.BFSRequire('buffer').Buffer;
       }


### PR DESCRIPTION
<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
Partial fix of #1187 

**What is the current behavior?**
codesandbox crashes in IE11

**What is the new behavior?**
Fixed 
```
Syntax error
vanilla (6,27)
```

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

[Arrow functions#Browser compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#Browser_compatibility)
