### PR TITLE
Disable fork button while forking

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Header/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/index.tsx
@@ -44,7 +44,10 @@ type ButtonProps = {
   signals: any;
   style: React.CSSProperties;
   secondary?: boolean;
-  disabled?: boolean;
+};
+
+type ForkButtonProps = ButtonProps & {
+  isForking: boolean;
 };
 
 const LikeButton = ({
@@ -65,19 +68,24 @@ const LikeButton = ({
   />
 );
 
-const ForkButton = ({ signals, secondary, disabled, style }: ButtonProps) => (
+const ForkButton = ({
+  signals,
+  secondary,
+  isForking,
+  style,
+}: ForkButtonProps) => (
   <Button
     onClick={() => {
       signals.editor.forkSandboxClicked();
     }}
     style={style}
     secondary={secondary}
-    disabled={disabled}
+    disabled={isForking}
     small
   >
     <>
       <Fork style={{ marginRight: '.5rem' }} />
-      Fork
+      {isForking ? 'Forking' : 'Fork'}
     </>
   </Button>
 );
@@ -212,7 +220,7 @@ const Header = ({ store, signals, zenMode }: Props) => {
         />
         <ForkButton
           secondary={sandbox.owned}
-          disabled={store.editor.isForkingSandbox}
+          isForking={store.editor.isForkingSandbox}
           style={{ fontSize: '.75rem' }}
           signals={signals}
           store={store}

--- a/packages/app/src/app/pages/Sandbox/Editor/Header/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/index.tsx
@@ -85,7 +85,7 @@ const ForkButton = ({
   >
     <>
       <Fork style={{ marginRight: '.5rem' }} />
-      {isForking ? 'Forking' : 'Fork'}
+      {isForking ? 'Forking...' : 'Fork'}
     </>
   </Button>
 );

--- a/packages/app/src/app/pages/Sandbox/Editor/Header/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/index.tsx
@@ -44,6 +44,7 @@ type ButtonProps = {
   signals: any;
   style: React.CSSProperties;
   secondary?: boolean;
+  disabled?: boolean;
 };
 
 const LikeButton = ({
@@ -64,13 +65,14 @@ const LikeButton = ({
   />
 );
 
-const ForkButton = ({ signals, secondary, style }: ButtonProps) => (
+const ForkButton = ({ signals, secondary, disabled, style }: ButtonProps) => (
   <Button
     onClick={() => {
       signals.editor.forkSandboxClicked();
     }}
     style={style}
     secondary={secondary}
+    disabled={disabled}
     small
   >
     <>
@@ -210,6 +212,7 @@ const Header = ({ store, signals, zenMode }: Props) => {
         />
         <ForkButton
           secondary={sandbox.owned}
+          disabled={store.editor.isForkingSandbox}
           style={{ fontSize: '.75rem' }}
           signals={signals}
           store={store}

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/More/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/More/index.tsx
@@ -41,7 +41,7 @@ class More extends React.PureComponent<Props> {
               disabled={isForkingSandbox}
               onClick={this.forkSandbox}
             >
-              {isForkingSandbox ? 'Forking Sandbox' : 'Fork Sandbox'}
+              {isForkingSandbox ? 'Forking Sandbox...' : 'Fork Sandbox'}
             </Button>
           ) : (
             <SignInButton block />

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/More/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/More/index.tsx
@@ -27,6 +27,7 @@ class More extends React.PureComponent<Props> {
 
   render() {
     const { owned } = this.props.store.editor.currentSandbox;
+    const { isForkingSandbox } = this.props.store.editor;
     const message = !owned ? NOT_OWNED_MESSAGE : NOT_SIGNED_IN_MESSAGE;
 
     return (
@@ -34,8 +35,13 @@ class More extends React.PureComponent<Props> {
         <Description>{message}</Description>
         <Margin margin={1}>
           {!owned ? (
-            <Button small block onClick={this.forkSandbox}>
-              Fork Sandbox
+            <Button
+              small
+              block
+              disabled={isForkingSandbox}
+              onClick={this.forkSandbox}
+            >
+              {isForkingSandbox ? 'Forking Sandbox' : 'Fork Sandbox'}
             </Button>
           ) : (
             <SignInButton block />


### PR DESCRIPTION
Fixes #844.

This is a first improvement:
![fork-btn](https://user-images.githubusercontent.com/2678610/55194102-f64b5b00-51a8-11e9-8728-016715690aa8.gif)

After this, I'd like to work on a better feedback, maybe a circular loader inside the button. What do you think?


**Checklist**:
- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A
