### PR TITLE
Start Preview's history at index of 0

### DIFF
--- a/packages/common/src/components/Preview/index.tsx
+++ b/packages/common/src/components/Preview/index.tsx
@@ -170,7 +170,7 @@ class BasePreview extends React.Component<Props, State> {
     this.state = {
       frameInitialized: false,
       history: [],
-      historyPosition: -1,
+      historyPosition: 0,
       urlInAddressBar: this.serverPreview
         ? getSSEUrl(props.sandbox.id, props.initialPath)
         : frameUrl(props.sandbox.id, props.initialPath || ''),


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**

Bug fix

<!-- You can also link to an open issue here -->
**What is the current behavior?**

The browser preview starts with an empty `history` array in state and a `historyPosition` of `-1`. After initializing, the URL listener dispatches a `REPLACE`, which adds an entry to the preview's `history` array, but the `historyPosition` is still `-1`. This causes two incorrect behaviors: 1) the preview thinks that it can go forward immediately and 2) the preview can never return to the initial location.

(I made the `REPLACE` change in #1158, so I suppose that this bug is my fault. I'm not sure how I didn't notice the issue until now, but I didn't spot any other changes, so it must have existed since that PR.)

<!-- if this is a feature change -->
**What is the new behavior?**

By starting with the `historyPosition` of `0`, the preview 1) cannot go forward immediately and 2) can return to the initial location.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
