### PR TITLE
add min width 100 to both panes

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Content/index.js
+++ b/packages/app/src/app/pages/Sandbox/Editor/Content/index.js
@@ -515,6 +515,7 @@ class EditorPreview extends React.Component<Props, State> {
             }
           />
           <SplitPane
+            maxSize={-100}
             onDragFinished={() => {
               this.props.signals.editor.resizingStopped();
             }}
@@ -533,7 +534,9 @@ class EditorPreview extends React.Component<Props, State> {
             defaultSize={'50%'}
             pane1Style={
               windowVisible
-                ? {}
+                ? {
+                    minWidth: 100,
+                  }
                 : {
                     width: '100%',
                     minWidth: '100%',


### PR DESCRIPTION
Adds a min-width of 100px to both panes so you can't drag anything out of view

![Screenshot 2019-04-01 at 11 13 08](https://user-images.githubusercontent.com/1051509/55316741-570bb980-546f-11e9-982b-4d34404604fe.png)

closes #1615