### PR TITLE
Set max size on drag resize handlers

### DIFF
--- a/packages/app/src/app/components/Preview/DevTools/index.tsx
+++ b/packages/app/src/app/components/Preview/DevTools/index.tsx
@@ -219,9 +219,7 @@ export default class DevTools extends React.PureComponent<Props, State> {
     });
   };
 
-  getCurrentPane = () => {
-    return this.props.viewConfig.views[this.state.currentPaneIndex];
-  };
+  getCurrentPane = () => this.props.viewConfig.views[this.state.currentPaneIndex];
 
   updateStatus = (id: string) => (
     status: 'success' | 'warning' | 'error' | 'info' | 'clear',
@@ -397,9 +395,7 @@ export default class DevTools extends React.PureComponent<Props, State> {
     });
   };
 
-  getViews = (): IViews => {
-    return this.allViews;
-  };
+  getViews = (): IViews => this.allViews;
 
   node: HTMLElement;
   allViews: IViews;
@@ -425,9 +421,15 @@ export default class DevTools extends React.PureComponent<Props, State> {
         }}
         style={{
           height: primary ? '100%' : height,
-          minHeight: height,
           position: 'relative',
           display: 'flex',
+          maxHeight: '100%',
+          /**
+           * Necessary to ensure it drags naturally. Otherwise there's an issue
+           * where flex tries to allocate equal space to the preview and the terminal,
+           * resulting in a very jaggy experience
+           */
+          flexShrink: 0,
         }}
       >
         {!hideTabs && (

--- a/packages/app/src/app/components/Preview/DevTools/index.tsx
+++ b/packages/app/src/app/components/Preview/DevTools/index.tsx
@@ -219,7 +219,8 @@ export default class DevTools extends React.PureComponent<Props, State> {
     });
   };
 
-  getCurrentPane = () => this.props.viewConfig.views[this.state.currentPaneIndex];
+  getCurrentPane = () =>
+    this.props.viewConfig.views[this.state.currentPaneIndex];
 
   updateStatus = (id: string) => (
     status: 'success' | 'warning' | 'error' | 'info' | 'clear',
@@ -427,9 +428,10 @@ export default class DevTools extends React.PureComponent<Props, State> {
           /**
            * Necessary to ensure it drags naturally. Otherwise there's an issue
            * where flex tries to allocate equal space to the preview and the terminal,
-           * resulting in a very jaggy experience
+           * resulting in a very jaggy experience. We set flex-shrink to 0 only
+           * for the console, and not for the preview
            */
-          flexShrink: 0,
+          flexShrink: devToolIndex === 1 ? 0 : 1,
         }}
       >
         {!hideTabs && (


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
Fix issue #639 where the terminal's height going way above the editor's height, resulting in issues with dragging.

<!-- You can also link to an open issue here -->
**What is the current behavior?**
https://github.com/CompuIves/codesandbox-client/issues/639

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation (*NA*)
- [ ] Tests (*NA*)
- [x] Ready to be merged
- [ ] Added myself to contributors table (*NA*)

Added `flexShrink: 0` to the terminal. Necessary to ensure it drags naturally. Otherwise there's an issue where flex tries to allocate equal space to the preview and the terminal, resulting in a very jaggy experience

<!-- Thank you for contributing! -->
