### PR TITLE
Preview Tabs Fixes

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -42,6 +42,7 @@
     "@types/codemirror": "^0.0.72",
     "@types/debug": "^4.1.1",
     "@types/gsap": "^1.20.1",
+    "@types/jest": "^24.0.11",
     "@types/lodash-es": "^4.17.2",
     "@types/react": "^16.8.3",
     "@types/react-dom": "^16.0.11",
@@ -273,8 +274,17 @@
     "testPathIgnorePatterns": [
       "/create-zip\\/.*\\/files/"
     ],
+    "testRegex": "(test|spec)\\.(j|t)sx?$",
     "transformIgnorePatterns": [
       "node_modules/(?!(common|lodash-es|sandbox-hooks|react-icons)/.+\\.js$)"
+    ],
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
     ],
     "moduleNameMapper": {
       "\\.css$": "<rootDir>/__mocks__/styleMock.js",

--- a/packages/app/src/app/pages/Sandbox/Editor/Content/__snapshots__/utils.test.ts.snap
+++ b/packages/app/src/app/pages/Sandbox/Editor/Content/__snapshots__/utils.test.ts.snap
@@ -1,0 +1,126 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`moveDevToolsTab can move a tab from one devtools to the other 1`] = `
+Array [
+  Object {
+    "views": Array [
+      Object {
+        "id": "codesandbox.tests",
+      },
+    ],
+  },
+  Object {
+    "views": Array [
+      Object {
+        "id": "codesandbox.console",
+      },
+      Object {
+        "id": "codesandbox.browser",
+      },
+      Object {
+        "id": "codesandbox.problems",
+      },
+    ],
+  },
+]
+`;
+
+exports[`moveDevToolsTab can move a tab from one devtools to the other and move it back 1`] = `
+Array [
+  Object {
+    "views": Array [
+      Object {
+        "id": "codesandbox.browser",
+      },
+      Object {
+        "id": "codesandbox.tests",
+      },
+    ],
+  },
+  Object {
+    "views": Array [
+      Object {
+        "id": "codesandbox.console",
+      },
+      Object {
+        "id": "codesandbox.problems",
+      },
+    ],
+  },
+]
+`;
+
+exports[`moveDevToolsTab can move a tab in same devtools 1`] = `
+Array [
+  Object {
+    "views": Array [
+      Object {
+        "id": "codesandbox.tests",
+      },
+      Object {
+        "id": "codesandbox.browser",
+      },
+    ],
+  },
+  Object {
+    "views": Array [
+      Object {
+        "id": "codesandbox.console",
+      },
+      Object {
+        "id": "codesandbox.problems",
+      },
+    ],
+  },
+]
+`;
+
+exports[`moveDevToolsTab can move a tab in same devtools and move the tab back 1`] = `
+Array [
+  Object {
+    "views": Array [
+      Object {
+        "id": "codesandbox.browser",
+      },
+      Object {
+        "id": "codesandbox.tests",
+      },
+    ],
+  },
+  Object {
+    "views": Array [
+      Object {
+        "id": "codesandbox.console",
+      },
+      Object {
+        "id": "codesandbox.problems",
+      },
+    ],
+  },
+]
+`;
+
+exports[`moveDevToolsTab can move the tab to the same position 1`] = `
+Array [
+  Object {
+    "views": Array [
+      Object {
+        "id": "codesandbox.browser",
+      },
+      Object {
+        "id": "codesandbox.tests",
+      },
+    ],
+  },
+  Object {
+    "views": Array [
+      Object {
+        "id": "codesandbox.console",
+      },
+      Object {
+        "id": "codesandbox.problems",
+      },
+    ],
+  },
+]
+`;

--- a/packages/app/src/app/pages/Sandbox/Editor/Content/index.js
+++ b/packages/app/src/app/pages/Sandbox/Editor/Content/index.js
@@ -5,7 +5,6 @@ import { Prompt } from 'react-router-dom';
 import { reaction } from 'mobx';
 import { TextOperation } from 'ot';
 import { inject, observer } from 'mobx-react';
-import { uniqBy } from 'lodash-es';
 
 import { getSandboxOptions } from '@codesandbox/common/lib/url';
 import getTemplateDefinition from '@codesandbox/common/lib/templates';

--- a/packages/app/src/app/pages/Sandbox/Editor/Content/index.js
+++ b/packages/app/src/app/pages/Sandbox/Editor/Content/index.js
@@ -5,6 +5,7 @@ import { Prompt } from 'react-router-dom';
 import { reaction } from 'mobx';
 import { TextOperation } from 'ot';
 import { inject, observer } from 'mobx-react';
+import immer from 'immer';
 
 import { getSandboxOptions } from '@codesandbox/common/lib/url';
 import getTemplateDefinition from '@codesandbox/common/lib/templates';
@@ -20,7 +21,6 @@ import Preview from './Preview';
 import preventGestureScroll, { removeListener } from './prevent-gesture-scroll';
 import Tabs from './Tabs';
 import { moveDevToolsTab } from './utils';
-import immer from 'immer';
 
 const settings = store =>
   ({

--- a/packages/app/src/app/pages/Sandbox/Editor/Content/index.js
+++ b/packages/app/src/app/pages/Sandbox/Editor/Content/index.js
@@ -20,6 +20,7 @@ import DevTools from 'app/components/Preview/DevTools';
 import Preview from './Preview';
 import preventGestureScroll, { removeListener } from './prevent-gesture-scroll';
 import Tabs from './Tabs';
+import { moveDevToolsTab } from './utils';
 
 const settings = store =>
   ({
@@ -382,25 +383,7 @@ class EditorPreview extends React.Component<Props, State> {
     const { store, signals } = this.props;
     const tabs = getPreviewTabs(store.editor.currentSandbox);
 
-    const prevDevTools = tabs[prevPos.devToolIndex];
-    const nextDevTools = tabs[nextPos.devToolIndex];
-    const prevTab = tabs[prevPos.devToolIndex].views[prevPos.tabPosition];
-
-    prevDevTools.views = prevDevTools.views.filter(
-      (_, i) => i !== prevPos.tabPosition
-    );
-
-    nextDevTools.views.splice(nextPos.tabPosition, 0, prevTab);
-
-    const newTabs = tabs.map((t, i) => {
-      if (i === prevPos.devToolIndex) {
-        return prevDevTools;
-      } else if (i === nextPos.devToolIndex) {
-        return nextDevTools;
-      }
-
-      return t;
-    });
+    const newTabs = moveDevToolsTab(tabs, prevPos, nextPos);
 
     const code = JSON.stringify({ preview: newTabs }, null, 2);
     const previousFile =

--- a/packages/app/src/app/pages/Sandbox/Editor/Content/index.js
+++ b/packages/app/src/app/pages/Sandbox/Editor/Content/index.js
@@ -7,6 +7,7 @@ import { TextOperation } from 'ot';
 import { inject, observer } from 'mobx-react';
 import immer from 'immer';
 
+import { getSandboxOptions } from '@codesandbox/common/lib/url';
 import getTemplateDefinition from '@codesandbox/common/lib/templates';
 import type { ModuleError } from '@codesandbox/common/lib/types';
 import { getPreviewTabs } from '@codesandbox/common/lib/templates/devtools';
@@ -482,6 +483,7 @@ class EditorPreview extends React.Component<Props, State> {
 
       return false;
     };
+
     const views = this.getViews();
 
     const browserConfig = {

--- a/packages/app/src/app/pages/Sandbox/Editor/Content/index.js
+++ b/packages/app/src/app/pages/Sandbox/Editor/Content/index.js
@@ -399,9 +399,9 @@ class EditorPreview extends React.Component<Props, State> {
 
       const sandboxOptions = getSandboxOptions(location.href);
       if (
-        (sandboxOptions.previewWindow &&
-          sandboxOptions.previewWindow === 'tests') ||
-        sandboxOptions.previewWindow === 'console'
+        sandboxOptions.previewWindow &&
+        (sandboxOptions.previewWindow === 'tests' ||
+          sandboxOptions.previewWindow === 'console')
       ) {
         // Backwards compatibility for ?previewwindow=
 

--- a/packages/app/src/app/pages/Sandbox/Editor/Content/utils.test.ts
+++ b/packages/app/src/app/pages/Sandbox/Editor/Content/utils.test.ts
@@ -1,0 +1,82 @@
+import { moveDevToolsTab } from './utils';
+
+const BROWSER_FIXTURE = { id: 'codesandbox.browser' };
+const TESTS_FIXTURE = { id: 'codesandbox.tests' };
+const CONSOLE_FIXTURE = { id: 'codesandbox.console' };
+const PROBLEMS_FIXTURE = { id: 'codesandbox.problems' };
+
+describe('moveDevToolsTab', () => {
+  it('can move a tab in same devtools', () => {
+    const tabs = [
+      { views: [{ ...BROWSER_FIXTURE }, { ...TESTS_FIXTURE }] },
+      { views: [{ ...CONSOLE_FIXTURE }, { ...PROBLEMS_FIXTURE }] },
+    ];
+    const newTabs = moveDevToolsTab(
+      tabs,
+      { devToolIndex: 0, tabPosition: 0 },
+      { devToolIndex: 0, tabPosition: 1 }
+    );
+
+    expect(newTabs).toMatchSnapshot();
+  });
+
+  it('can move a tab in same devtools and move the tab back', () => {
+    const tabs = [
+      { views: [{ ...BROWSER_FIXTURE }, { ...TESTS_FIXTURE }] },
+      { views: [{ ...CONSOLE_FIXTURE }, { ...PROBLEMS_FIXTURE }] },
+    ];
+    const from = { devToolIndex: 0, tabPosition: 0 };
+    const to = { devToolIndex: 0, tabPosition: 1 };
+    const newTabs = moveDevToolsTab(tabs, from, to);
+
+    expect(moveDevToolsTab(newTabs, to, from)).toMatchSnapshot();
+  });
+
+  it('can move the tab to the same position', () => {
+    const tabs = [
+      { views: [{ ...BROWSER_FIXTURE }, { ...TESTS_FIXTURE }] },
+      { views: [{ ...CONSOLE_FIXTURE }, { ...PROBLEMS_FIXTURE }] },
+    ];
+    const from = { devToolIndex: 0, tabPosition: 0 };
+    const to = { devToolIndex: 0, tabPosition: 0 };
+    const newTabs = moveDevToolsTab(tabs, from, to);
+
+    expect(newTabs).toMatchSnapshot();
+  });
+
+  it('can move a tab from one devtools to the other', () => {
+    const tabs = [
+      { views: [{ ...BROWSER_FIXTURE }, { ...TESTS_FIXTURE }] },
+      { views: [{ ...CONSOLE_FIXTURE }, { ...PROBLEMS_FIXTURE }] },
+    ];
+    const from = { devToolIndex: 0, tabPosition: 0 };
+    const to = { devToolIndex: 1, tabPosition: 1 };
+    const newTabs = moveDevToolsTab(tabs, from, to);
+
+    expect(newTabs).toMatchSnapshot();
+  });
+
+  it('can move a tab from one devtools to the other and move it back', () => {
+    const tabs = [
+      { views: [{ ...BROWSER_FIXTURE }, { ...TESTS_FIXTURE }] },
+      { views: [{ ...CONSOLE_FIXTURE }, { ...PROBLEMS_FIXTURE }] },
+    ];
+    const from = { devToolIndex: 0, tabPosition: 0 };
+    const to = { devToolIndex: 1, tabPosition: 1 };
+    const newTabs = moveDevToolsTab(tabs, from, to);
+
+    expect(moveDevToolsTab(newTabs, to, from)).toMatchSnapshot();
+  });
+
+  it('is immutable', () => {
+    const tabs = [
+      { views: [{ ...BROWSER_FIXTURE }, { ...TESTS_FIXTURE }] },
+      { views: [{ ...CONSOLE_FIXTURE }, { ...PROBLEMS_FIXTURE }] },
+    ];
+    const from = { devToolIndex: 0, tabPosition: 0 };
+    const to = { devToolIndex: 1, tabPosition: 1 };
+    const newTabs = moveDevToolsTab(tabs, from, to);
+
+    expect(newTabs).not.toBe(tabs);
+  });
+});

--- a/packages/app/src/app/pages/Sandbox/Editor/Content/utils.ts
+++ b/packages/app/src/app/pages/Sandbox/Editor/Content/utils.ts
@@ -1,0 +1,40 @@
+import immer from 'immer';
+import { ViewConfig } from '@codesandbox/common/lib/templates/template';
+import { ITabPosition } from 'app/components/Preview/DevTools/Tabs';
+
+const isEqual = (prevPos: ITabPosition, nextPos: ITabPosition) =>
+  prevPos.devToolIndex === nextPos.devToolIndex &&
+  prevPos.tabPosition === nextPos.tabPosition;
+
+export function moveDevToolsTab(
+  tabs: ViewConfig[],
+  prevPos: ITabPosition,
+  nextPos: ITabPosition
+) {
+  if (isEqual(prevPos, nextPos)) {
+    return tabs;
+  }
+
+  // We want to do this immutable, to prevent conflicts while the file is changing
+  return immer(tabs, draft => {
+    const prevDevTools = draft[prevPos.devToolIndex];
+    const nextDevTools = draft[nextPos.devToolIndex];
+    const prevTab = draft[prevPos.devToolIndex].views[prevPos.tabPosition];
+
+    prevDevTools.views = prevDevTools.views.filter(
+      (_, i) => i !== prevPos.tabPosition
+    );
+
+    nextDevTools.views.splice(nextPos.tabPosition, 0, prevTab);
+
+    draft.map((t, i) => {
+      if (i === prevPos.devToolIndex) {
+        return prevDevTools;
+      } else if (i === nextPos.devToolIndex) {
+        return nextDevTools;
+      }
+
+      return t;
+    });
+  });
+}

--- a/packages/common/src/templates/devtools/index.ts
+++ b/packages/common/src/templates/devtools/index.ts
@@ -1,7 +1,9 @@
 import getTemplateDefinition from '../';
 import { resolveModule } from '../../sandbox/modules';
+import { ViewConfig } from '../template';
+import { Sandbox } from '../../types';
 
-export const getPreviewTabs = sandbox => {
+export const getPreviewTabs = (sandbox: Sandbox) => {
   const template = getTemplateDefinition(sandbox.template);
 
   let views = template.getViews();
@@ -13,7 +15,9 @@ export const getPreviewTabs = sandbox => {
       sandbox.directories
     );
 
-    const { preview } = JSON.parse(workspaceConfig.code);
+    const { preview } = JSON.parse(workspaceConfig.code) as {
+      preview: ViewConfig[];
+    };
 
     if (preview && Array.isArray(preview)) {
       views = preview;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2621,6 +2621,13 @@
   version "22.2.3"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-22.2.3.tgz#0157c0316dc3722c43a7b71de3fdf3acbccef10d"
 
+"@types/jest@^24.0.11":
+  version "24.0.11"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.11.tgz#1f099bea332c228ea6505a88159bfa86a5858340"
+  integrity sha512-2kLuPC5FDnWIDvaJBzsGTBQaBbnDweznicvK7UGYzlIJP4RJR2a4A/ByLUXEyEgag6jz8eHdlWExGDtH3EYUXQ==
+  dependencies:
+    "@types/jest-diff" "*"
+
 "@types/jest@^24.0.9":
   version "24.0.9"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.9.tgz#74ce9cf337f25e189aa18f76ab3d65e8669b55f2"


### PR DESCRIPTION
Add support for ?previewwindow and prevent duplicate tabs. Generally improves the function responsible for moving tabs since the mutations now happen in `immer`. There's now a smaller chance of mutation weirdness.

Fixes #1672
Fixes #1651