### PR TITLE
Fix(homepage): Second picked sandbox doesn't open in explore

### DIFF
--- a/packages/homepage/src/screens/explore/SandboxModal.js
+++ b/packages/homepage/src/screens/explore/SandboxModal.js
@@ -43,7 +43,7 @@ export default class SandboxModal extends React.PureComponent {
   };
   loadedSandboxes = {};
 
-  getSandbox = (sandboxId: string) => {
+  getSandbox = sandboxId => {
     track('Explore Sandbox Open', { sandboxId });
 
     if (this.loadedSandboxes[sandboxId]) {
@@ -71,7 +71,7 @@ export default class SandboxModal extends React.PureComponent {
 
     const sandbox = await this.getSandbox(props.sandboxId);
 
-    this.setState({ sandbox });
+    this.setState({ sandbox, showFrame: true });
 
     if (this.frame) {
       await this.frameInitializedPromise;
@@ -86,10 +86,6 @@ export default class SandboxModal extends React.PureComponent {
     this.frameInitializedPromise = new Promise(resolve => {
       this.resolveFrameInitializedPromise = resolve;
     });
-
-    setTimeout(() => {
-      this.setState({ showFrame: true });
-    }, 1000);
   }
 
   componentWillUnmount() {
@@ -118,7 +114,10 @@ export default class SandboxModal extends React.PureComponent {
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.sandboxId !== this.props.sandboxId) {
-      this.setState({ sandbox: undefined });
+      this.setState({
+        sandbox: undefined,
+        showFrame: false,
+      });
       this.fetchSandbox(nextProps);
     }
   }


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
Fix issue #1690 where Second picked sandbox doesn't open in explore sandcodebox

<!-- You can also link to an open issue here -->
**What is the current behavior?**
#1690 

<!-- if this is a feature change -->
**What is the new behavior?**
Able to open second picked sandbox in popup and navigate to left and right with new sandbox


<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
