### PR TITLE
fix UX confusion with Github

### DIFF
--- a/packages/app/src/app/pages/Dashboard/Content/CreateNewSandbox/Modal/index.js
+++ b/packages/app/src/app/pages/Dashboard/Content/CreateNewSandbox/Modal/index.js
@@ -82,10 +82,7 @@ export default class Modal extends React.PureComponent {
             </Tab>
           ))}
           <ImportChoices>
-            <ImportChoice
-              href="/docs/importing#import-from-github"
-              target="_blank"
-            >
+            <ImportChoice href="/s/github" target="_blank">
               <GithubLogo /> Import from GitHub
             </ImportChoice>
             <ImportChoice

--- a/packages/app/src/app/pages/GitHub/index.js
+++ b/packages/app/src/app/pages/GitHub/index.js
@@ -75,7 +75,14 @@ class GitHub extends React.PureComponent {
                 <SubTitle>
                   Enter the URL to your GitHub repository to generate a URL to
                   your sandbox. The sandbox will stay in sync with your
-                  repository.
+                  repository.<br />
+                  <a
+                    href="/docs/importing#import-from-github"
+                    rel="noopener norefereer"
+                    target="_blank"
+                  >
+                    See the docs
+                  </a>
                 </SubTitle>
               </Description>
 


### PR DESCRIPTION
Adds a link from the import from Github to the actual link to import from GitHub.

In there is a link to the docs


closes #1209 