### PR TITLE
#1719 Pick Sandbox is now shown at header when user is a curator

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Header/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/index.tsx
@@ -91,6 +91,29 @@ const ForkButton = ({
   </Button>
 );
 
+const PickButton = ({ store, signals, secondary, style }: ButtonProps) => {
+  const { id, title, description } = store.editor.currentSandbox;
+
+  return (
+    <Button
+      onClick={() => {
+        signals.editor.pickSandboxModal({
+          details: {
+            id,
+            title,
+            description,
+          },
+        });
+      }}
+      style={style}
+      secondary={secondary}
+      small
+    >
+      Pick
+    </Button>
+  );
+};
+
 const ShareButton = ({ signals, secondary, style }: ButtonProps) => (
   <Button
     onClick={() => {
@@ -217,17 +240,28 @@ const Header = ({ store, signals, zenMode }: Props) => {
             likeCount={store.editor.currentSandbox.likeCount}
           />
         )}
-        <ShareButton
-          style={{ fontSize: '.75rem', margin: '0 1rem' }}
-          signals={signals}
-          secondary={!sandbox.owned}
-          store={store}
-        />
+
+        {store.user.curatorAt && (
+          <PickButton
+            style={{ fontSize: '.75rem', margin: '0 1rem' }}
+            secondary={sandbox.owned}
+            signals={signals}
+            store={store}
+          />
+        )}
+
         <ForkButton
           secondary={sandbox.owned}
           isForking={store.editor.isForkingSandbox}
           style={{ fontSize: '.75rem' }}
           signals={signals}
+          store={store}
+        />
+
+        <ShareButton
+          style={{ fontSize: '.75rem', margin: '0 1rem' }}
+          signals={signals}
+          secondary={!sandbox.owned}
           store={store}
         />
 

--- a/packages/app/src/app/pages/Sandbox/Editor/Header/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/index.tsx
@@ -97,7 +97,7 @@ const PickButton = ({ store, signals, secondary, style }: ButtonProps) => {
   return (
     <Button
       onClick={() => {
-        signals.editor.pickSandboxModal({
+        signals.explore.pickSandboxModal({
           details: {
             id,
             title,
@@ -241,27 +241,28 @@ const Header = ({ store, signals, zenMode }: Props) => {
           />
         )}
 
-        {store.user.curatorAt && (
-          <PickButton
-            style={{ fontSize: '.75rem', margin: '0 1rem' }}
-            secondary={sandbox.owned}
-            signals={signals}
-            store={store}
-          />
-        )}
+        {store.user &&
+          store.user.curatorAt && (
+            <PickButton
+              style={{ fontSize: '.75rem' }}
+              secondary={sandbox.owned}
+              signals={signals}
+              store={store}
+            />
+          )}
+
+        <ShareButton
+          style={{ fontSize: '.75rem', margin: '0 1rem' }}
+          signals={signals}
+          secondary={!sandbox.owned}
+          store={store}
+        />
 
         <ForkButton
           secondary={sandbox.owned}
           isForking={store.editor.isForkingSandbox}
           style={{ fontSize: '.75rem' }}
           signals={signals}
-          store={store}
-        />
-
-        <ShareButton
-          style={{ fontSize: '.75rem', margin: '0 1rem' }}
-          signals={signals}
-          secondary={!sandbox.owned}
           store={store}
         />
 

--- a/packages/app/src/app/store/modules/editor/index.js
+++ b/packages/app/src/app/store/modules/editor/index.js
@@ -16,6 +16,7 @@ import {
 } from './getters';
 import { isModuleSynced, shouldDirectoryBeOpen } from './computed';
 import { loadSandbox } from '../../sequences';
+import { pickSandboxModal } from '../explore/sequences';
 
 export default Module({
   model,
@@ -82,6 +83,7 @@ export default Module({
     moduleDoubleClicked: sequences.unsetDirtyTab,
     tabClosed: sequences.closeTab,
     tabMoved: sequences.moveTab,
+    pickSandboxModal,
     prettifyClicked: sequences.prettifyCode,
     errorsCleared: sequences.clearErrors,
     projectViewToggled: sequences.toggleProjectView,

--- a/packages/app/src/app/store/modules/editor/index.js
+++ b/packages/app/src/app/store/modules/editor/index.js
@@ -16,7 +16,6 @@ import {
 } from './getters';
 import { isModuleSynced, shouldDirectoryBeOpen } from './computed';
 import { loadSandbox } from '../../sequences';
-import { pickSandboxModal } from '../explore/sequences';
 
 export default Module({
   model,
@@ -83,7 +82,6 @@ export default Module({
     moduleDoubleClicked: sequences.unsetDirtyTab,
     tabClosed: sequences.closeTab,
     tabMoved: sequences.moveTab,
-    pickSandboxModal,
     prettifyClicked: sequences.prettifyCode,
     errorsCleared: sequences.clearErrors,
     projectViewToggled: sequences.toggleProjectView,


### PR DESCRIPTION

**What kind of change does this PR introduce?**
Added feature #1719 where Pick Sandbox is added at header when the user is the curator.

**What is the current behavior?**
#1719 

**What is the new behavior?**
The user who is a curator will see the Pick button at the header of the sandbox.

**Checklist**:
- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged 
- [ ] Added myself to contributors table
