### PR TITLE
Put the devtools counter back

### DIFF
--- a/packages/app/src/app/components/Preview/DevTools/Tabs/Tab/UnreadDevToolsCount.tsx
+++ b/packages/app/src/app/components/Preview/DevTools/Tabs/Tab/UnreadDevToolsCount.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { StatusType } from '../..';
+
+const Container = styled.div<{ unread: number; status: StatusType }>`
+  transition: 0.3s ease all;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 0.5rem;
+  margin-left: 0.75rem;
+  border-radius: 50%;
+  height: 16px;
+  width: 16px;
+  color: ${({ unread }) =>
+    unread === 0 ? `rgba(255, 255, 255, 0.4)` : 'white'};
+  background-color: ${({ status, unread, theme }) => {
+    if (unread === 0) {
+      return 'rgba(255, 255, 255, 0.2)';
+    }
+    if (status === 'info') {
+      return theme.secondary();
+    } else if (status === 'warning') {
+      return theme.primary.darken(0.3)();
+    } else if (status === 'error') {
+      return theme.red();
+    } else if (status === 'success') {
+      return theme.green();
+    }
+    return 'black';
+  }};
+`;
+
+export function UnreadDevToolsCount({ status, unread }) {
+  return (
+    <Container unread={unread} status={status}>
+      {unread}
+    </Container>
+  );
+}

--- a/packages/app/src/app/components/Preview/DevTools/Tabs/Tab/index.tsx
+++ b/packages/app/src/app/components/Preview/DevTools/Tabs/Tab/index.tsx
@@ -10,8 +10,9 @@ import {
 import CrossIcon from 'react-icons/lib/md/clear';
 
 import { Tab, CloseTab } from './elements';
-import { IViewType } from '../..';
+import { IViewType, Status } from '../..';
 import { ITabPosition } from '..';
+import { UnreadDevToolsCount } from './UnreadDevToolsCount';
 
 export interface TabProps {
   active: boolean;
@@ -22,6 +23,7 @@ export interface TabProps {
   index: number;
   devToolIndex: number;
   canDrag: boolean;
+  status: Status | undefined;
 }
 
 interface DragProps {
@@ -88,6 +90,8 @@ export const PaneTab = ({
   connectDropTarget,
   isOver,
   isDragging,
+  devToolIndex,
+  status,
 }: TabProps & DragProps) => {
   useGlobalDim(isDragging);
 
@@ -101,6 +105,11 @@ export const PaneTab = ({
         isOver={isOver && !isDragging}
       >
         {pane.title}
+
+        {devToolIndex !== 0 &&
+          status && (
+            <UnreadDevToolsCount status={status.type} unread={status.unread} />
+          )}
         {false &&
         active && ( // This will be enabled later on
             <CloseTab>

--- a/packages/app/src/app/components/Preview/DevTools/Tabs/index.tsx
+++ b/packages/app/src/app/components/Preview/DevTools/Tabs/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import Tooltip from '@codesandbox/common/lib/components/Tooltip';
 
-import { IViewType } from '..';
+import { IViewType, Status } from '..';
 import { Actions, Container, Tabs } from './elements';
 import DraggableTab, { PaneTab, TabProps } from './Tab';
 import TabDropZone, { TabDropZoneProps } from './TabDropZone';
@@ -20,6 +20,7 @@ export interface Props {
   setPane: (i: number) => void;
   devToolIndex: number;
   moveTab: (prevPos: ITabPosition, newPos: ITabPosition) => void;
+  status?: { [title: string]: Status | undefined };
 }
 
 const DevToolTabs = ({
@@ -30,6 +31,7 @@ const DevToolTabs = ({
   owned,
   setPane,
   moveTab,
+  status,
 }: Props) => {
   const currentPane = panes[currentPaneIndex];
   const actions =
@@ -68,6 +70,7 @@ const DevToolTabs = ({
               moveTab={moveTab}
               index={i}
               key={i}
+              status={status ? status[pane.id] : undefined}
             />
           );
         })}

--- a/packages/app/src/app/components/Preview/DevTools/index.tsx
+++ b/packages/app/src/app/components/Preview/DevTools/index.tsx
@@ -448,6 +448,7 @@ export default class DevTools extends React.PureComponent<Props, State> {
               hidden={hidden}
               setPane={this.setPane}
               devToolIndex={devToolIndex}
+              status={this.state.status}
               moveTab={
                 this.props.moveTab
                   ? (prevPos, nextPos) => {


### PR DESCRIPTION
Only for the secondary devtools (so the bottom tabs)

![image](https://user-images.githubusercontent.com/587016/55629726-38315e00-57b4-11e9-8ea8-5e0d5f400d32.png)
