### PR TITLE
Show a loader on the button while forking

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Header/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/index.tsx
@@ -82,6 +82,7 @@ const ForkButton = ({
     style={style}
     secondary={secondary}
     disabled={isForking}
+    loading={isForking}
     small
   >
     <>

--- a/packages/app/src/app/pages/Sandbox/Editor/Header/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Header/index.tsx
@@ -8,6 +8,7 @@ import SettingsIcon from 'react-icons/lib/md/settings';
 import ShareIcon from 'react-icons/lib/md/share';
 import SaveIcon from 'react-icons/lib/md/save';
 import { Button } from '@codesandbox/common/lib/components/Button';
+import ProgressButton from '@codesandbox/common/lib/components/ProgressButton';
 import SignInButton from 'app/pages/common/SignInButton';
 
 import { saveAllModules } from 'app/store/modules/editor/utils';
@@ -75,13 +76,12 @@ const ForkButton = ({
   isForking,
   style,
 }: ForkButtonProps) => (
-  <Button
+  <ProgressButton
     onClick={() => {
       signals.editor.forkSandboxClicked();
     }}
     style={style}
     secondary={secondary}
-    disabled={isForking}
     loading={isForking}
     small
   >
@@ -89,7 +89,7 @@ const ForkButton = ({
       <Fork style={{ marginRight: '.5rem' }} />
       {isForking ? 'Forking...' : 'Fork'}
     </>
-  </Button>
+  </ProgressButton>
 );
 
 const PickButton = ({ store, signals, secondary, style }: ButtonProps) => {

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/More/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/More/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { inject, observer } from 'mobx-react';
 
-import { Button } from '@codesandbox/common/lib/components/Button';
+import ProgressButton from '@codesandbox/common/lib/components/ProgressButton';
 import SignInButton from 'app/pages/common/SignInButton';
 import Margin from '@codesandbox/common/lib/components/spacing/Margin';
 import track from '@codesandbox/common/lib/utils/analytics';
@@ -35,15 +35,14 @@ class More extends React.Component<Props> {
         <Description>{message}</Description>
         <Margin margin={1}>
           {!owned ? (
-            <Button
+            <ProgressButton
               small
               block
-              disabled={isForkingSandbox}
               loading={isForkingSandbox}
               onClick={this.forkSandbox}
             >
               {isForkingSandbox ? 'Forking Sandbox...' : 'Fork Sandbox'}
-            </Button>
+            </ProgressButton>
           ) : (
             <SignInButton block />
           )}

--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/More/index.tsx
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/items/More/index.tsx
@@ -39,6 +39,7 @@ class More extends React.Component<Props> {
               small
               block
               disabled={isForkingSandbox}
+              loading={isForkingSandbox}
               onClick={this.forkSandbox}
             >
               {isForkingSandbox ? 'Forking Sandbox...' : 'Fork Sandbox'}

--- a/packages/common/src/components/Button/elements.ts
+++ b/packages/common/src/components/Button/elements.ts
@@ -1,11 +1,10 @@
-import styled, { css, keyframes } from 'styled-components';
+import styled, { css } from 'styled-components';
 import Link from 'react-router-dom/Link';
 import theme from '../../theme';
 
 export type OptionProps = {
   theme: any;
   disabled?: boolean;
-  loading?: boolean;
   red?: boolean;
   secondary?: boolean;
   danger?: boolean;
@@ -98,39 +97,14 @@ const getBorder = ({
   return '2px solid #66B9F4';
 };
 
-const progressAnimation = keyframes`
-  0%   { transform: scale(0); }
-  100% { transform: scale(1); }
-`;
-
-const getLoader = ({ disabled }: OptionProps) => css`
-  &:before {
-    content: ' ';
-    position: absolute;
-    width: 20px;
-    height: 20px;
-    left: 50%;
-    top: 50%;
-    bottom: 0;
-    margin-left: -10px;
-    margin-top: -10px;
-    border-radius: 50%;
-    opacity: 0.5;
-    background: white;
-    animation: ${progressAnimation} 0.7s ease-in-out infinite alternate;
-  }
-`;
-
 const styles = css<{
   disabled?: boolean;
-  loading?: boolean;
   secondary?: boolean;
   danger?: boolean;
   red?: boolean;
   block?: boolean;
   small?: boolean;
 }>`
-  position: relative;
   transition: 0.3s ease all;
   font-family: Poppins, Roboto, sans-serif;
 
@@ -176,8 +150,6 @@ const styles = css<{
     ${props => getBackgroundHoverColor(props)};
     ${props => getHoverColor(props)};
   }
-
-  ${props => props.loading && getLoader(props)};
 `;
 
 export const LinkButton = styled(Link)`

--- a/packages/common/src/components/Button/elements.ts
+++ b/packages/common/src/components/Button/elements.ts
@@ -1,10 +1,11 @@
-import styled, { css } from 'styled-components';
+import styled, { css, keyframes } from 'styled-components';
 import Link from 'react-router-dom/Link';
 import theme from '../../theme';
 
 export type OptionProps = {
   theme: any;
   disabled?: boolean;
+  loading?: boolean;
   red?: boolean;
   secondary?: boolean;
   danger?: boolean;
@@ -97,14 +98,39 @@ const getBorder = ({
   return '2px solid #66B9F4';
 };
 
+const progressAnimation = keyframes`
+  0%   { transform: scale(0); }
+  100% { transform: scale(1); }
+`;
+
+const getLoader = ({ disabled }: OptionProps) => css`
+  &:before {
+    content: ' ';
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    left: 50%;
+    top: 50%;
+    bottom: 0;
+    margin-left: -10px;
+    margin-top: -10px;
+    border-radius: 50%;
+    opacity: 0.5;
+    background: white;
+    animation: ${progressAnimation} 0.7s ease-in-out infinite alternate;
+  }
+`;
+
 const styles = css<{
   disabled?: boolean;
+  loading?: boolean;
   secondary?: boolean;
   danger?: boolean;
   red?: boolean;
   block?: boolean;
   small?: boolean;
 }>`
+  position: relative;
   transition: 0.3s ease all;
   font-family: Poppins, Roboto, sans-serif;
 
@@ -150,6 +176,8 @@ const styles = css<{
     ${props => getBackgroundHoverColor(props)};
     ${props => getHoverColor(props)};
   }
+
+  ${props => props.loading && getLoader(props)};
 `;
 
 export const LinkButton = styled(Link)`

--- a/packages/common/src/components/Button/index.tsx
+++ b/packages/common/src/components/Button/index.tsx
@@ -11,6 +11,7 @@ type Props = {
   children?: React.ReactElement | string;
   disabled?: boolean;
   type?: 'button' | 'reset' | 'submit';
+  loading?: boolean;
   secondary?: boolean;
 };
 

--- a/packages/common/src/components/Button/index.tsx
+++ b/packages/common/src/components/Button/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { LinkButton, AButton, Button } from './elements';
 
-type Props = {
+export type Props = {
   to?: string;
   href?: string;
   small?: boolean;
@@ -11,7 +11,6 @@ type Props = {
   children?: React.ReactElement | string;
   disabled?: boolean;
   type?: 'button' | 'reset' | 'submit';
-  loading?: boolean;
   secondary?: boolean;
 };
 

--- a/packages/common/src/components/ProgressButton/elements.ts
+++ b/packages/common/src/components/ProgressButton/elements.ts
@@ -1,0 +1,44 @@
+import styled, { css, keyframes } from 'styled-components';
+import theme from '../../theme';
+
+const loaderAnimation = keyframes`
+  0%   { background-color:  ${theme.secondary()}; }
+  50%, 100% { background-color: ${theme.secondary.lighten(0.5)()}; }
+`;
+
+export const Wrapper = styled.div`
+  position: relative;
+`;
+
+const circle = css`
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: ${theme.secondary()};
+  opacity: 0.5;
+  animation: ${loaderAnimation} 1s infinite linear alternate;
+`;
+
+export const Loader = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  ${circle} animation-delay: 0.5s;
+
+  &:before {
+    content: ' ';
+    position: absolute;
+    left: -15px;
+    ${circle};
+    animation-delay: 0s;
+  }
+
+  &:after {
+    content: ' ';
+    position: absolute;
+    left: 15px;
+    ${circle};
+    animation-delay: 1s;
+  }
+`;

--- a/packages/common/src/components/ProgressButton/elements.ts
+++ b/packages/common/src/components/ProgressButton/elements.ts
@@ -11,11 +11,11 @@ export const Wrapper = styled.div`
 `;
 
 const circle = css`
-  width: 10px;
-  height: 10px;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
   background: ${theme.secondary()};
-  opacity: 0.5;
+  opacity: 0.7;
   animation: ${loaderAnimation} 1s infinite linear alternate;
 `;
 
@@ -29,7 +29,7 @@ export const Loader = styled.div`
   &:before {
     content: ' ';
     position: absolute;
-    left: -15px;
+    left: -12px;
     ${circle};
     animation-delay: 0s;
   }
@@ -37,7 +37,7 @@ export const Loader = styled.div`
   &:after {
     content: ' ';
     position: absolute;
-    left: 15px;
+    left: 12px;
     ${circle};
     animation-delay: 1s;
   }

--- a/packages/common/src/components/ProgressButton/index.tsx
+++ b/packages/common/src/components/ProgressButton/index.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Button, Props as ButtonProps } from '../Button';
+import { Wrapper, Loader } from './elements';
+
+type Props = ButtonProps & {
+  loading?: boolean;
+};
+
+function ProgressButton({
+  loading = false,
+  disabled = false,
+  ...props
+}: Props) {
+  return (
+    <Wrapper>
+      <Button disabled={disabled || loading} {...props} />
+      {loading && <Loader />}
+    </Wrapper>
+  );
+}
+
+export default ProgressButton;


### PR DESCRIPTION
This is a follow-up of #1667.

![animated-fork](https://user-images.githubusercontent.com/2678610/55198483-6e6c4d80-51b6-11e9-9bb8-3395eba28ec9.gif)

The effect is simple because for now I didn't want to modify the markup of the button.

With my limited CSS skills, I think @CompuIves suggestion regarding nzbin.github.io/three-dots would require to have a div wrapper around the button and a div to display the 3 dots. Do we want to do this?
