### PR TITLE
Bug fixed : file explorer not displaying anything

### DIFF
--- a/packages/react-sandpack/src/components/FileExplorer/ModuleList/ModuleList.tsx
+++ b/packages/react-sandpack/src/components/FileExplorer/ModuleList/ModuleList.tsx
@@ -21,27 +21,18 @@ export default class ModuleList extends React.PureComponent<Props> {
       prefixedPath,
       files,
     } = this.props;
+    
+    const fileListWithoutPrefix = Object.keys(files)
+      .filter(file => file.startsWith(prefixedPath))
+      .map(file => file.substring(prefixedPath.length));
 
-    const filesToShow: { path: string }[] = [];
-    const directoriesToShow: Set<string> = new Set();
-    const pathParts = prefixedPath.split('/');
+    const directoriesToShow = new Set(fileListWithoutPrefix
+      .filter(file => file.includes('/'))
+      .map(file => `${prefixedPath}${file.split('/')[0]}/`));
 
-    Object.keys(files).forEach(path => {
-      if (path.startsWith(prefixedPath)) {
-        const filePathParts = path.split('/');
-
-        if (filePathParts.length === pathParts.length) {
-          if (path.endsWith('/')) {
-            directoriesToShow.add(path);
-          } else {
-            filesToShow.push({ path });
-          }
-        } else if (filePathParts.length === pathParts.length + 1) {
-          filePathParts.pop();
-          directoriesToShow.add(filePathParts.join('/') + '/');
-        }
-      }
-    });
+    const filesToShow = fileListWithoutPrefix
+      .filter(file => !file.includes('/'))
+      .map(file => ({ path: `${prefixedPath}${file}` }));
 
     return (
       <div style={{ marginLeft: `${0.5 * depth}rem` }}>


### PR DESCRIPTION
Hi,
I want to try codesandbox in storybook (and thus vice versa)

When the project has not got any file in the subdirectory but only folders, 
the file explorer is not displaying anything.

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
This is a fix to the file explorer in react codesandbox

<!-- You can also link to an open issue here -->
**What is the current behavior?**
![image](https://user-images.githubusercontent.com/1233790/55653828-faeac180-57ef-11e9-9180-7557565a9d3b.png)

<!-- if this is a feature change -->
**What is the new behavior?**
It will keep the display consistent accross any project.
This was debugged thanks to these unit tests : 

```javascript
import { modulesList } from './index'

test("empty list", () => {
  const result = modulesList({}, '')
  const { directoriesToShow, filesToShow } = result
  expect(directoriesToShow).toEqual(new Set([]))
});

test("simple case", () => {
  const result = modulesList({
    "/src/panel.js": {},
    "/src/panel.stories.js": {},
    "/src/storysource/bootstrapper.js": {},
    "/package.json": {}
  }, "/")
  const { directoriesToShow, filesToShow } = result
  expect(directoriesToShow).toEqual(new Set(['/src/']))
  expect(filesToShow).toEqual([{ path: '/package.json' }])
})

test("real case 0", () => {
  const result = modulesList({
    "/src/components/BaseButton.js": {},
    "/src/stories/notes/notes.md": {},
    "/src/stories/addon-notes.stories.js": {},
    "/src/storysource/bootstrapper.js": {},
    "/package.json": {}
  },
    "/")
  const { directoriesToShow, filesToShow } = result
  expect(directoriesToShow).toEqual(new Set(['/src/']))
  expect(filesToShow).toEqual([{ path: '/package.json' }])
})

test("real case 1", () => {
  const result = modulesList({
    "/src/components/BaseButton.js": {},
    "/src/stories/notes/notes.md": {},
    "/src/stories/addon-notes.stories.js": {},
    "/src/storysource/bootstrapper.js": {},
    "/package.json": {}
  },
    "/src/")
  const { directoriesToShow, filesToShow } = result
  expect(directoriesToShow).toEqual(new Set(['/src/components/', '/src/stories/', '/src/storysource/']))
  expect(filesToShow).toEqual([])
})

test("real case 2", () => {
  const result = modulesList({
    "/src/components/BaseButton.js": {},
    "/src/stories/notes/notes.md": {},
    "/src/stories/addon-notes.stories.js": {},
    "/src/storysource/bootstrapper.js": {},
    "/package.json": {}
  },
    "/src/components/")
  const { directoriesToShow, filesToShow } = result
  expect(directoriesToShow).toEqual(new Set([]))
  expect(filesToShow).toEqual([{ path: "/src/components/BaseButton.js" }])
})
```

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [N/A] Documentation
- [x] Tests (as comment above but react-sandpack does not seem to be using a test framework...)
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [N/A] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
