### PR TITLE
Add a tooltip for each VersionEntry button

### DIFF
--- a/packages/app/src/app/pages/Sandbox/Editor/Workspace/Dependencies/VersionEntry/index.js
+++ b/packages/app/src/app/pages/Sandbox/Editor/Workspace/Dependencies/VersionEntry/index.js
@@ -3,6 +3,7 @@ import CrossIcon from 'react-icons/lib/md/clear';
 import RefreshIcon from 'react-icons/lib/md/refresh';
 import ArrowDropDown from 'react-icons/lib/md/keyboard-arrow-down';
 import ArrowDropUp from 'react-icons/lib/md/keyboard-arrow-up';
+import Tooltip from '@codesandbox/common/lib/components/Tooltip';
 
 import { EntryContainer, IconArea, Icon } from '../../elements';
 import { Link } from '../elements';
@@ -121,16 +122,25 @@ export default class VersionEntry extends React.PureComponent {
           {hovering && (
             <IconArea>
               {size.size ? (
-                <Icon onClick={this.handleOpen}>
-                  {open ? <ArrowDropUp /> : <ArrowDropDown />}
-                </Icon>
+                <Tooltip
+                  content={open ? 'Hide sizes' : 'Show sizes'}
+                  style={{ outline: 'none' }}
+                >
+                  <Icon onClick={this.handleOpen}>
+                    {open ? <ArrowDropUp /> : <ArrowDropDown />}
+                  </Icon>
+                </Tooltip>
               ) : null}
-              <Icon onClick={this.handleRefresh}>
-                <RefreshIcon />
-              </Icon>
-              <Icon onClick={this.handleRemove}>
-                <CrossIcon />
-              </Icon>
+              <Tooltip content="Update to latest" style={{ outline: 'none' }}>
+                <Icon onClick={this.handleRefresh}>
+                  <RefreshIcon />
+                </Icon>
+              </Tooltip>
+              <Tooltip content="Remove" style={{ outline: 'none' }}>
+                <Icon onClick={this.handleRemove}>
+                  <CrossIcon />
+                </Icon>
+              </Tooltip>
             </IconArea>
           )}
         </EntryContainer>


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
A tooltip was added for each version entry action: 
- Show/Hide sizes
- Update to latest
- Remove

![image](https://user-images.githubusercontent.com/2678610/55655051-59fe0580-57f3-11e9-85ba-cd15daed1714.png)

<!-- You can also link to an open issue here -->
**What is the current behavior?**
There is no tooltip and the Refresh button is not 100% obvious.

<!-- if this is a feature change -->
**What is the new behavior?**
There is now a tooltip for each action


I had to force `outline: none` to avoid having a blue square around the icon:
![image](https://user-images.githubusercontent.com/2678610/55655103-8285ff80-57f3-11e9-9f9f-c9539b776da4.png)


