### PR TITLE
Terminal does resize with it's container

### DIFF
--- a/packages/app/src/app/components/Preview/DevTools/Terminal/index.js
+++ b/packages/app/src/app/components/Preview/DevTools/Terminal/index.js
@@ -177,7 +177,10 @@ class TerminalComponent extends React.Component<Props, State> {
     const { height, hidden } = this.props;
 
     return (
-      <div ref={this.setupResizeObserver}>
+      <div
+        style={{ width: '100%', height: '100%' }}
+        ref={this.setupResizeObserver}
+      >
         {!hidden &&
           this.state.shells.length > 0 && (
             <ShellTabs


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
Fixed bug #1654 where Terminal does not resize with its container
<!-- You can also link to an open issue here -->
**What is the current behavior?**
Terminal does resize with its container
<!-- if this is a feature change -->
**What is the new behavior?**


<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
The bug occurred when `ResizeObserver` was not called even though the HTML element `ResizeObserver` was listening to changed, I gave `height` and `width` to this element to `100%` to fix the issue.

<!-- Thank you for contributing! -->
