### PR TITLE
Homepage - Fix frameworks text / icons overflowing at mobile rez

### DIFF
--- a/packages/homepage/src/screens/home/Frameworks/index.js
+++ b/packages/homepage/src/screens/home/Frameworks/index.js
@@ -89,15 +89,25 @@ const Intro = styled(Column)`
 `;
 
 const Icons = styled.div`
-  display: flex;
-  justify-content: space-around;
   margin-top: 1rem;
   margin-bottom: 4rem;
-  flex: 1;
   min-width: 100%;
 
   ${media.phone`
     margin: 2rem 0;
+    width: 100%;
+  `};
+`;
+
+const ScrollAtMobile = styled.div`
+  display: flex;
+  flex: 1;
+  justify-content: space-around;
+  min-width: 100%;
+
+  ${media.phone`
+    justify-content: flex-start;
+    overflow-x: scroll;
   `};
 `;
 
@@ -115,6 +125,7 @@ const IconContainer = styled.div`
   }
 
   ${media.phone`
+    flex-shrink: 0;
     width: 96px;
     height: 96px;
 
@@ -285,23 +296,25 @@ export default class Frameworks extends React.Component {
       <Pane width={1280}>
         <Flex>
           <Icons>
-            {templates.map(({ name }, i) => {
-              const TIcon = getIcon(name);
+            <ScrollAtMobile>
+              {templates.map(({ name }, i) => {
+                const TIcon = getIcon(name);
 
-              return (
-                <IconContainer
-                  // eslint-disable-next-line
-                  key={i}
-                  selected={templates[i] === template}
-                  template={templates[i]}
-                  onClick={() => {
-                    this.setTemplate(templates[i]);
-                  }}
-                >
-                  <TIcon width={80} height={80} />
-                </IconContainer>
-              );
-            })}
+                return (
+                  <IconContainer
+                    // eslint-disable-next-line
+                    key={i}
+                    selected={templates[i] === template}
+                    template={templates[i]}
+                    onClick={() => {
+                      this.setTemplate(templates[i]);
+                    }}
+                  >
+                    <TIcon width={80} height={80} />
+                  </IconContainer>
+                );
+              })}
+            </ScrollAtMobile>
           </Icons>
 
           <Intro style={{ marginRight: '2rem' }}>


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
Bug fix - cosmetic

<!-- You can also link to an open issue here -->
**What is the current behavior?**
Currently the text & icons in the 'Tailored for web applications' section flow off the screen at mobile resolution.

Bug report - #1745 

<img width="219" alt="Screenshot 2019-04-08 at 22 02 39" src="https://user-images.githubusercontent.com/21317379/55757385-b9565280-5a4b-11e9-8e5b-52ae52527e05.png">

<!-- if this is a feature change -->
**What is the new behavior?**
- Text no longer flows off the screen 
- Framework icons can be scrolled horizontally by the user
- Homepage appears as before at desktop resolution

<img width="223" alt="Screenshot 2019-04-08 at 22 02 50" src="https://user-images.githubusercontent.com/21317379/55757960-44841800-5a4d-11e9-9e24-f3b7cf643c8e.png">

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation - N/A
- [ ] Tests - N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions --> - N/A

<!-- feel free to add additional comments -->

Scrolling behaviour could be removed and replaced with wrapping icons; but this could affect the UX of clicking a framework icon and viewing the information underneath.

<!-- Thank you for contributing! -->
