### PR TITLE
Fix: Sandbox title is not changed, if the name change from dashboard

### DIFF
--- a/packages/app/src/app/store/sequences.js
+++ b/packages/app/src/app/store/sequences.js
@@ -151,6 +151,10 @@ const setSandboxData = [
         state`editor.sandboxes.${props`sandbox.id`}.userLiked`,
         props`sandbox.userLiked`
       ),
+      set(
+        state`editor.sandboxes.${props`sandbox.id`}.title`,
+        props`sandbox.title`
+      ),
     ],
   },
 ];


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
This issue fixes a bug and maintains resonance of the sandbox name between the dashboard and the header.

<!-- You can also link to an open issue here -->
**What is the current behavior?**
#1750 
<!-- if this is a feature change -->
**What is the new behavior?**
Now the sandbox name between the dashboard and the header is same


<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
