### PR TITLE
feat(template): add Adonis template

### DIFF
--- a/packages/common/src/components/logos/Adonis.tsx
+++ b/packages/common/src/components/logos/Adonis.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+
+export default ({ width = 32, height = 32, className }) => (
+  <svg
+    className={className}
+    height={height}
+    viewBox="0 0 36 33"
+    width={width}
+  >
+    <g
+      fill="none"
+      fill-rule="evenodd"
+      transform="translate(0 .5)"
+    >
+      <path
+        d="M20 2.236L5.618 31h28.764L20 2.236z"
+        stroke="#a666ff"
+        stroke-width="2"
+      />
+      <path
+        d="M12 2l12 24H0"
+        fill="#a666ff"
+      />
+    </g>
+  </svg>
+);

--- a/packages/common/src/templates/adonis.ts
+++ b/packages/common/src/templates/adonis.ts
@@ -1,0 +1,16 @@
+import Template from './template';
+import { decorateSelector } from '../theme';
+
+ export default new Template(
+  'adonis',
+  'AdonisJs',
+  'https://adonisjs.com/',
+  'github/adonisjs/adonis-starter-codesandbox',
+  decorateSelector(() => '#a666ff'),
+  {
+    isServer: true,
+    mainFile: ['/start/routes.js'],
+    showOnHomePage: true,
+    netlify: false,
+  }
+);

--- a/packages/common/src/templates/icons.ts
+++ b/packages/common/src/templates/icons.ts
@@ -1,3 +1,4 @@
+import Adonis from '../components/logos/Adonis';
 import React from '../components/logos/React';
 import Angular from '../components/logos/Angular';
 import Ember from '../components/logos/Ember';
@@ -22,6 +23,7 @@ import MDXDeck from '../components/logos/mdx-deck';
 import GridSome from '../components/logos/Gridsome';
 
 import {
+  adonis,
   react,
   ember,
   vue,
@@ -58,6 +60,8 @@ export type ReturnedIcon = React.SFC<{
 
 export default function getIcon(theme: TemplateType): ReturnedIcon {
   switch (theme) {
+    case adonis.name:
+      return Adonis;
     case react.name:
       return React;
     case vue.name:

--- a/packages/common/src/templates/index.ts
+++ b/packages/common/src/templates/index.ts
@@ -1,3 +1,4 @@
+import adonis from './adonis';
 import angular from './angular';
 import babel from './babel';
 import parcel from './parcel';
@@ -25,6 +26,7 @@ import vuepress from './vuepress';
 import mdxDeck from './mdx-deck';
 
 export {
+  adonis,
   angular,
   custom,
   apollo,
@@ -53,6 +55,7 @@ export {
 };
 
 export type TemplateType =
+  | 'adonis'
   | 'create-react-app'
   | 'vue-cli'
   | 'preact-cli'
@@ -77,6 +80,8 @@ export type TemplateType =
 
 export default function getDefinition(theme: TemplateType) {
   switch (theme) {
+    case adonis.name:
+      return adonis;
     case react.name:
       return react;
     case vue.name:


### PR DESCRIPTION
Hey all! 👋 

This PR add AdonisJs as a template.

When I tested locally the code I wasn't able to load my template as server side container. It took the `create-react-app` template by default.

I don't know if I need to add a `sandbox.config.json` to the root of [our repository](https://github.com/adonisjs/adonis-starter-codesandbox) or it's normal and will be fixed when the `importers` PR will be merged.

Importers PR: *Not yet created*